### PR TITLE
ES-696: confirm users before they reload the page 

### DIFF
--- a/signup-ui/src/pages/ResetPasswordPage/ResetPasswordPage.tsx
+++ b/signup-ui/src/pages/ResetPasswordPage/ResetPasswordPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
+import { isEqual } from "lodash";
 import { Resolver, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as yup from "yup";
@@ -69,7 +70,12 @@ export const ResetPasswordPage = ({ settings }: ResetPasswordPageProps) => {
       // Step 3 - ResetPassword
       yup.object({
         newPassword: validatePassword(settings, t),
-        confirmNewPassword: validateConfirmPassword("newPassword", settings, t, false),
+        confirmNewPassword: validateConfirmPassword(
+          "newPassword",
+          settings,
+          t,
+          false
+        ),
       }),
       // Step 4 - ResetPasswordStatus
       yup.object({}),
@@ -92,13 +98,19 @@ export const ResetPasswordPage = ({ settings }: ResetPasswordPageProps) => {
   });
 
   const {
+    getValues,
     formState: { isDirty },
   } = methods;
 
   useEffect(() => {
+    if (isEqual(resetPasswordFormDefaultValues, getValues())) return;
+
     if (
       step === ResetPasswordStep.ResetPasswordConfirmation ||
-      (criticalError && criticalError.errorCode === "invalid_transaction")
+      (criticalError &&
+        ["invalid_transaction", "knowledgebase_mismatch"].includes(
+          criticalError.errorCode
+        ))
     )
       return;
 
@@ -115,7 +127,7 @@ export const ResetPasswordPage = ({ settings }: ResetPasswordPageProps) => {
     return () => {
       window.removeEventListener("beforeunload", handleTabBeforeUnload);
     };
-  }, [step, criticalError]);
+  }, [step, criticalError, getValues()]);
 
   const getResetPasswordContent = (step: ResetPasswordStep) => {
     switch (step) {
@@ -137,9 +149,9 @@ export const ResetPasswordPage = ({ settings }: ResetPasswordPageProps) => {
   return (
     <>
       {criticalError &&
-        ["invalid_transaction", "knowledgebase_mismatch"].includes(criticalError.errorCode) && (
-          <ResetPasswordPopover />
-        )}
+        ["invalid_transaction", "knowledgebase_mismatch"].includes(
+          criticalError.errorCode
+        ) && <ResetPasswordPopover />}
       <Form {...methods}>
         <form>{getResetPasswordContent(step)}</form>
       </Form>


### PR DESCRIPTION
### Issue

[Able to refresh the screen after filling some inputs without any popup reminder](https://mosip.atlassian.net/browse/ES-696)

### Solution

Show prompts before users can reload the page.