### PR TITLE
ES-756

### DIFF
--- a/signup-service/src/main/java/io/mosip/signup/services/CacheUtilService.java
+++ b/signup-service/src/main/java/io/mosip/signup/services/CacheUtilService.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
@@ -28,16 +29,16 @@ public class CacheUtilService {
     }
 
     @CacheEvict(value = SignUpConstants.CHALLENGE_GENERATED, key = "#transactionId")
-    @Cacheable(value = SignUpConstants.CHALLENGE_VERIFIED, key = "#transactionId")
-    public RegistrationTransaction setChallengeVerifiedTransaction(String transactionId,
+    @Cacheable(value = SignUpConstants.CHALLENGE_VERIFIED, key = "#verifiedTransactionId")
+    public RegistrationTransaction setChallengeVerifiedTransaction(String transactionId, String verifiedTransactionId,
                                                                    RegistrationTransaction registrationTransaction) {
         return registrationTransaction;
     }
 
     @CacheEvict(value = SignUpConstants.CHALLENGE_VERIFIED, key = "#transactionId")
-    @Cacheable(value = SignUpConstants.REGISTERED_CACHE, key = "#transactionId")
-    public RegistrationTransaction setRegisteredTransaction(String transactionId,
-                                                 RegistrationTransaction registrationTransaction) {
+    @CachePut(value = SignUpConstants.STATUS_CHECK, key = "#transactionId")
+    public RegistrationTransaction setStatusCheckTransaction(String transactionId,
+                                                             RegistrationTransaction registrationTransaction) {
         return registrationTransaction;
     }
 
@@ -65,8 +66,8 @@ public class CacheUtilService {
         return cacheManager.getCache(SignUpConstants.CHALLENGE_VERIFIED).get(transactionId, RegistrationTransaction.class);
     }
 
-    public RegistrationTransaction getRegisteredTransaction(String transactionId) {
-        return cacheManager.getCache(SignUpConstants.REGISTERED_CACHE).get(transactionId, RegistrationTransaction.class);
+    public RegistrationTransaction getStatusCheckTransaction(String transactionId) {
+        return cacheManager.getCache(SignUpConstants.STATUS_CHECK).get(transactionId, RegistrationTransaction.class);
     }
 
     public boolean isIdentifierBlocked(String identifier) {

--- a/signup-service/src/main/java/io/mosip/signup/util/SignUpConstants.java
+++ b/signup-service/src/main/java/io/mosip/signup/util/SignUpConstants.java
@@ -4,7 +4,7 @@ public class SignUpConstants {
 
     public static final String CHALLENGE_GENERATED = "challenge_generated";
     public static final String CHALLENGE_VERIFIED = "challenge_verified";
-    public static final String REGISTERED_CACHE = "status_check";
+    public static final String STATUS_CHECK = "status_check";
     public static final String BLOCKED_IDENTIFIER = "blocked_identifier";
     public static final String KEYSTORE = "keystore";
     public static final String KEY_ALIAS = "key_alias";

--- a/signup-service/src/test/java/io/mosip/signup/services/CacheUtilServiceTest.java
+++ b/signup-service/src/test/java/io/mosip/signup/services/CacheUtilServiceTest.java
@@ -33,14 +33,14 @@ public class CacheUtilServiceTest {
 
         Assert.assertEquals(cacheUtilService.setChallengeGeneratedTransaction("mock",
                 registrationTransaction), registrationTransaction);
-        Assert.assertEquals(cacheUtilService.setChallengeVerifiedTransaction("mock",
+        Assert.assertEquals(cacheUtilService.setChallengeVerifiedTransaction("mock", "vmock",
                 registrationTransaction), registrationTransaction);
-        Assert.assertEquals(cacheUtilService.setRegisteredTransaction("mock",
+        Assert.assertEquals(cacheUtilService.setStatusCheckTransaction("mock",
                 registrationTransaction), registrationTransaction);
 
         Assert.assertNotNull(cacheUtilService.getChallengeGeneratedTransaction("mock"));
         Assert.assertNotNull(cacheUtilService.getChallengeVerifiedTransaction("mock"));
-        Assert.assertNotNull(cacheUtilService.getRegisteredTransaction("mock"));
+        Assert.assertNotNull(cacheUtilService.getStatusCheckTransaction("mock"));
     }
 
     @Test

--- a/signup-service/src/test/java/io/mosip/signup/services/RegistrationServiceTest.java
+++ b/signup-service/src/test/java/io/mosip/signup/services/RegistrationServiceTest.java
@@ -1862,8 +1862,8 @@ public class RegistrationServiceTest {
         String transactionId = "TRAN-1234";
         RegistrationTransaction registrationTransaction = new RegistrationTransaction("+85577410541", Purpose.REGISTRATION);
         registrationTransaction.setRegistrationStatus(RegistrationStatus.COMPLETED);
-        when(cacheUtilService.getRegisteredTransaction(transactionId)).thenReturn(registrationTransaction);
-        when(cacheUtilService.setRegisteredTransaction(transactionId, registrationTransaction)).thenReturn(registrationTransaction);
+        when(cacheUtilService.getStatusCheckTransaction(transactionId)).thenReturn(registrationTransaction);
+        when(cacheUtilService.setStatusCheckTransaction(transactionId, registrationTransaction)).thenReturn(registrationTransaction);
         RegistrationStatusResponse registrationStatusResponse = registrationService.getRegistrationStatus(transactionId);
 
         Assert.assertNotNull(registrationStatusResponse);
@@ -1875,8 +1875,8 @@ public class RegistrationServiceTest {
         String transactionId = "TRAN-1234";
         RegistrationTransaction registrationTransaction = new RegistrationTransaction("+85577410541", Purpose.REGISTRATION);
         registrationTransaction.setRegistrationStatus(RegistrationStatus.PENDING);
-        when(cacheUtilService.getRegisteredTransaction(transactionId)).thenReturn(registrationTransaction);
-        when(cacheUtilService.setRegisteredTransaction(transactionId, registrationTransaction)).thenReturn(registrationTransaction);
+        when(cacheUtilService.getStatusCheckTransaction(transactionId)).thenReturn(registrationTransaction);
+        when(cacheUtilService.setStatusCheckTransaction(transactionId, registrationTransaction)).thenReturn(registrationTransaction);
         RegistrationStatusResponse registrationStatusResponse = registrationService.getRegistrationStatus(transactionId);
 
         Assert.assertNotNull(registrationStatusResponse);
@@ -1888,8 +1888,8 @@ public class RegistrationServiceTest {
         String transactionId = "TRAN-1234";
         RegistrationTransaction registrationTransaction = new RegistrationTransaction("+85577410541", Purpose.REGISTRATION);
         registrationTransaction.setRegistrationStatus(RegistrationStatus.FAILED);
-        when(cacheUtilService.getRegisteredTransaction(transactionId)).thenReturn(registrationTransaction);
-        when(cacheUtilService.setRegisteredTransaction(transactionId, registrationTransaction)).thenReturn(registrationTransaction);
+        when(cacheUtilService.getStatusCheckTransaction(transactionId)).thenReturn(registrationTransaction);
+        when(cacheUtilService.setStatusCheckTransaction(transactionId, registrationTransaction)).thenReturn(registrationTransaction);
         RegistrationStatusResponse registrationStatusResponse = registrationService.getRegistrationStatus(transactionId);
 
         Assert.assertNotNull(registrationStatusResponse);


### PR DESCRIPTION
As the setStatusCheckTransaction method is annotated as cachable, second time update with latest status was not persisted. Hence status check always returned PENDING.
Instead of cacheable, annotated method with cacheput so that status is updated in the cache.