### PR TITLE
ES-1231

### DIFF
--- a/signup-ui/src/pages/ResetPasswordPage/ResetPasswordPage.tsx
+++ b/signup-ui/src/pages/ResetPasswordPage/ResetPasswordPage.tsx
@@ -61,7 +61,7 @@ export const ResetPasswordPage = ({ settings }: ResetPasswordPageProps) => {
       yup.object({
         username: validateUsername(settings),
         fullname: validateFullName(settings),
-        captchaToken: validateCaptchaToken(),
+        captchaToken: validateCaptchaToken(settings),
       }),
       // Step 2 - Otp
       yup.object({

--- a/signup-ui/src/pages/ResetPasswordPage/UserInfo/UserInfo.tsx
+++ b/signup-ui/src/pages/ResetPasswordPage/UserInfo/UserInfo.tsx
@@ -127,7 +127,8 @@ export const UserInfo = ({ settings, methods }: UserInfoProps) => {
     !isUserInfoDirty ||
     getValues("username") === resetPasswordFormDefaultValues.username ||
     getValues("fullname") === resetPasswordFormDefaultValues.fullname ||
-    getValues("captchaToken") === resetPasswordFormDefaultValues.captchaToken;
+    (settings.response.configs["send-challenge.captcha.required"] &&
+    getValues("captchaToken") === resetPasswordFormDefaultValues.captchaToken);
 
   const handleContinue = useCallback(
     async (e: MouseEvent<HTMLButtonElement>) => {
@@ -308,6 +309,7 @@ export const UserInfo = ({ settings, methods }: UserInfoProps) => {
                 )}
               />
               {/* ReCaptcha */}
+              {settings.response.configs["send-challenge.captcha.required"] && (
               <div id="captcha" className="flex items-center justify-center">
                 <ReCAPTCHA
                   ref={_reCaptchaRef}
@@ -317,6 +319,7 @@ export const UserInfo = ({ settings, methods }: UserInfoProps) => {
                   sitekey={settings.response.configs["captcha.site.key"] ?? ""}
                 />
               </div>
+              )}
             </div>
             <Button
               id="continue-button"

--- a/signup-ui/src/pages/SignUpPage/Phone/Phone.tsx
+++ b/signup-ui/src/pages/SignUpPage/Phone/Phone.tsx
@@ -118,7 +118,8 @@ export const Phone = ({ settings, methods }: PhoneProps) => {
     !isValid ||
     !isDirty ||
     getValues("phone") === signUpFormDefaultValues.phone ||
-    getValues("captchaToken") === signUpFormDefaultValues.captchaToken;
+    (settings.response.configs["send-challenge.captcha.required"] && 
+      getValues("captchaToken") === signUpFormDefaultValues.captchaToken);
 
   const handleContinue = useCallback(
     async (e: any) => {
@@ -258,7 +259,9 @@ export const Phone = ({ settings, methods }: PhoneProps) => {
                 </FormItem>
               )}
             />
-            <div id="captcha" className="flex items-center justify-center">
+            
+            {settings.response.configs["send-challenge.captcha.required"] && (
+              <div id="captcha" className="flex items-center justify-center">
               {/* I'm not a robot checkbox */}
               <ReCAPTCHA
                 ref={_reCaptchaRef}
@@ -268,6 +271,7 @@ export const Phone = ({ settings, methods }: PhoneProps) => {
                 sitekey={settings.response.configs["captcha.site.key"] ?? ""}
               />
             </div>
+            )}
           </div>
           <Button
             id="continue-button"

--- a/signup-ui/src/pages/SignUpPage/SignUpPage.tsx
+++ b/signup-ui/src/pages/SignUpPage/SignUpPage.tsx
@@ -77,7 +77,7 @@ export const SignUpPage = ({ settings }: SignUpPageProps) => {
       // Step 1 - Phone Validation
       yup.object({
         phone: validateUsername(settings),
-        captchaToken: validateCaptchaToken(),
+        captchaToken: validateCaptchaToken(settings),
       }),
       // Step 2 - OTP Validation
       yup.object({

--- a/signup-ui/src/pages/shared/validation.ts
+++ b/signup-ui/src/pages/shared/validation.ts
@@ -17,7 +17,8 @@ export const validateUsername = (settings: SettingsDto) =>
       );
     });
 
-export const validateCaptchaToken = () =>
+export const validateCaptchaToken = (settings: any) =>
+  settings.response.configs["send-challenge.captcha.required"] && 
   yup.string().required("captcha_token_validation");
 
 export const validateFullName = (settings: SettingsDto) =>


### PR DESCRIPTION
https://mosip.atlassian.net/browse/ES-1231
Before Change
- if we disable mosip.signup.send-challenge.captcha-required from backend, Captcha still appears for user to validate
![image](https://github.com/mosip/esignet-signup/assets/148301211/377babba-6435-4311-b00a-4b5360da5455)

After Change
- if we disable mosip.signup.send-challenge.captcha-required from backend, Captcha does not appear for user to validate
![Screenshot from 2024-06-26 15-29-27](https://github.com/mosip/esignet-signup/assets/148301211/846a4f74-0d4e-4278-95d5-2e8cf59bca99)
- if enable mosip.signup.send-challenge.captcha-required from backend, validate captcha logic remains working. 