### PR TITLE
ES-1184: The word in error message pop up is getting spilled over to next line

### DIFF
--- a/signup-ui/src/pages/EkycVerificationPage/EkycVerificationPopover.tsx
+++ b/signup-ui/src/pages/EkycVerificationPage/EkycVerificationPopover.tsx
@@ -50,7 +50,7 @@ export const EkycVerificationPopover = () => {
               {t("error")}
             </>
           </AlertDialogTitle>
-          <AlertDialogDescription className="break-all text-center text-muted-dark-gray">
+          <AlertDialogDescription className="text-center text-muted-dark-gray">
             {criticalError && t(`error_response.${criticalError.errorCode}`)}
           </AlertDialogDescription>
         </AlertDialogHeader>

--- a/signup-ui/src/pages/ResetPasswordPage/ResetPasswordConfirmation/components/ResetPasswordConfirmationLayout.tsx
+++ b/signup-ui/src/pages/ResetPasswordPage/ResetPasswordConfirmation/components/ResetPasswordConfirmationLayout.tsx
@@ -43,7 +43,7 @@ export const ResetPasswordConfirmationLayout = ({
               <h1>{t("password_reset_failed")}</h1>
             )}
           </div>
-          <p className="break-all text-center text-muted-neutral-gray">
+          <p className="text-center text-muted-neutral-gray">
             {message}
           </p>
         </div>

--- a/signup-ui/src/pages/SignUpPage/AccountRegistrationStatus/components/AccountRegistrationStatusLayout.tsx
+++ b/signup-ui/src/pages/SignUpPage/AccountRegistrationStatus/components/AccountRegistrationStatusLayout.tsx
@@ -45,7 +45,7 @@ export const AccountRegistrationStatusLayout = ({
               <h1>{t("signup_failed")}</h1>
             )}
           </div>
-          <p className="break-all text-center text-gray-500">{message}</p>
+          <p className="text-center text-gray-500">{message}</p>
         </div>
         <Button id="success-continue-button" className="my-4 h-16 w-full" onClick={handleAction}>
           {fromSignInHash ? t("login") : t("okay")}

--- a/signup-ui/src/pages/SignUpPage/SignUpPopover.tsx
+++ b/signup-ui/src/pages/SignUpPage/SignUpPopover.tsx
@@ -50,7 +50,7 @@ export const SignUpPopover = () => {
               {t("error")}
             </>
           </AlertDialogTitle>
-          <AlertDialogDescription className="break-all text-center text-muted-dark-gray">
+          <AlertDialogDescription className="text-center text-muted-dark-gray">
             {criticalError && t(`error_response.${criticalError.errorCode}`)}
           </AlertDialogDescription>
         </AlertDialogHeader>


### PR DESCRIPTION
## Ticket
[The word in error message pop up is getting spilled over to next line](https://mosip.atlassian.net/browse/ES-1184)

## Issue
The word in error message pop up is getting spilled over to next line

## Solution
Fix CSS issue