### PR TITLE
MOSIP-34887

### DIFF
--- a/signup-ui/src/pages/EkycVerificationPage/VerificationScreen/VerificationScreen.tsx
+++ b/signup-ui/src/pages/EkycVerificationPage/VerificationScreen/VerificationScreen.tsx
@@ -186,6 +186,29 @@ export const VerificationScreen = ({
     sendMessage(request);
   };
 
+  useEffect(() => {
+    // checking camera permission in every 1 second
+    const cameraCheckInterval = setInterval(
+      cameraDeviceCheck,
+      1000
+    );
+    return () => clearInterval(cameraCheckInterval);
+  }, []);
+
+  const cameraDeviceCheck = () => {
+    navigator.mediaDevices
+      .getUserMedia({ video: true })
+      .catch(stopEkycVerificationCheck);
+  };
+
+  const stopEkycVerificationCheck = (err: DOMException) => {
+    if (connected) {
+      unsubscribe();
+      client.deactivate();
+    }
+    setStep(EkycVerificationStep.IdentityVerificationStatus);
+  }
+
   const convertResponseToState = (
     res: IdentityVerificationResponseDto
   ): IdentityVerificationState => {


### PR DESCRIPTION
## Ticket

[MOSIP-34887](https://mosip.atlassian.net/browse/MOSIP-34887)

## Solution

1. checks for camera device for every 1 second
1. terminates ekyc verification and redirects user to identity verification screen

[MOSIP-34887]: https://mosip.atlassian.net/browse/MOSIP-34887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ