### PR TITLE
[ES-1902] Abrupt disconnection of WebSocket is not updating the verification status as Failed

### DIFF
--- a/signup-service/src/main/java/io/mosip/signup/controllers/WebSocketController.java
+++ b/signup-service/src/main/java/io/mosip/signup/controllers/WebSocketController.java
@@ -75,6 +75,7 @@ public class WebSocketController {
         String slotId = username.split(VALUE_SEPARATOR)[1];
 
         log.info("WebSocket Disconnected >>>>>> {}", username);
+        log.info("WebSocket Disconnected Status>>>>>> {}", disconnectEvent.getCloseStatus());
         if(!CloseStatus.NORMAL.equals(disconnectEvent.getCloseStatus())){
             IdentityVerificationTransaction transaction =
                     cacheUtilService.getVerifiedSlotTransaction(slotId);

--- a/signup-service/src/main/java/io/mosip/signup/controllers/WebSocketController.java
+++ b/signup-service/src/main/java/io/mosip/signup/controllers/WebSocketController.java
@@ -71,15 +71,17 @@ public class WebSocketController {
     @EventListener
     public void onDisconnected(SessionDisconnectEvent disconnectEvent) {
         String username = Objects.requireNonNull(disconnectEvent.getUser()).getName();
+        String transactionId = username.split(VALUE_SEPARATOR)[0];
+        String slotId = username.split(VALUE_SEPARATOR)[1];
+
         log.info("WebSocket Disconnected >>>>>> {}", username);
-        if(disconnectEvent.getCloseStatus()!=null && !disconnectEvent.getCloseStatus().equals(CloseStatus.NORMAL)){
+        if(!CloseStatus.NORMAL.equals(disconnectEvent.getCloseStatus())){
             IdentityVerificationTransaction transaction =
-                    cacheUtilService.getVerifiedSlotTransaction(username.split(VALUE_SEPARATOR)[1]);
+                    cacheUtilService.getVerifiedSlotTransaction(slotId);
             transaction.setStatus(VerificationStatus.FAILED);
-            cacheUtilService.updateVerifiedSlotTransaction(username.split(VALUE_SEPARATOR)[1], transaction);
+            cacheUtilService.updateVerifiedSlotTransaction(slotId, transaction);
         }
         cacheUtilService.removeFromSlotConnected(username);
-        cacheUtilService.evictSlotAllottedTransaction(username.split(VALUE_SEPARATOR)[0],
-                username.split(VALUE_SEPARATOR)[1]);
+        cacheUtilService.evictSlotAllottedTransaction(transactionId,slotId);
     }
 }

--- a/signup-service/src/test/java/io/mosip/signup/controllers/WebSocketControllerTest.java
+++ b/signup-service/src/test/java/io/mosip/signup/controllers/WebSocketControllerTest.java
@@ -111,13 +111,16 @@ public class WebSocketControllerTest {
                 return "TID"+VALUE_SEPARATOR+"SID";
             }
         });
+        IdentityVerificationTransaction transaction = new IdentityVerificationTransaction();
+        transaction.setStatus(VerificationStatus.FAILED);
+        Mockito.when(cacheUtilService.getVerifiedSlotTransaction(Mockito.anyString())).thenReturn(transaction);
         webSocketController.onDisconnected(sessionDisconnectEvent);
         Mockito.verify(cacheUtilService, Mockito.times(1)).removeFromSlotConnected(Mockito.anyString());
         Mockito.verify(cacheUtilService, Mockito.times(1)).evictSlotAllottedTransaction(Mockito.anyString(),Mockito.anyString());
     }
 
     @Test
-    public void onDisconnectedAbnormalClosedState_test() {
+    public void onDisconnected_WithAbnormalClosedState_test() {
         SessionDisconnectEvent sessionDisconnectEvent =  Mockito.mock(SessionDisconnectEvent.class);
         Mockito.when(sessionDisconnectEvent.getUser()).thenReturn(new  java.security.Principal() {
             @Override


### PR DESCRIPTION
Identify if its abnormal disconnection.

If abnormal is confirmed, then update the verified_slot transaction as “FAILED” and save the transaction.

other logic to remove/evict the allotted slot will remain the same.