### PR TITLE
[ES-1927] verifying slotid in topic subscribe event

### DIFF
--- a/signup-service/src/main/java/io/mosip/signup/config/WebSocketConfig.java
+++ b/signup-service/src/main/java/io/mosip/signup/config/WebSocketConfig.java
@@ -6,8 +6,10 @@
 package io.mosip.signup.config;
 
 import io.mosip.signup.services.WebSocketHandshakeHandler;
+import io.mosip.signup.util.WebSocketChannelInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -19,6 +21,14 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Autowired
     private WebSocketHandshakeHandler webSocketHandshakeHandler;
+
+    @Autowired
+    private WebSocketChannelInterceptor webSocketChannelInterceptor;
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(webSocketChannelInterceptor);
+    }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {

--- a/signup-service/src/main/java/io/mosip/signup/util/WebSocketChannelInterceptor.java
+++ b/signup-service/src/main/java/io/mosip/signup/util/WebSocketChannelInterceptor.java
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 package io.mosip.signup.util;
 
 import io.mosip.signup.services.CacheUtilService;
@@ -17,12 +22,14 @@ public class WebSocketChannelInterceptor implements ChannelInterceptor {
     @Autowired
     private CacheUtilService cacheUtilService;
 
+    final static private String SLOT_SUBSCRIPTION_DESTINATION_PREFIX = "/topic/";
+
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
         if(isSlotSubscriptionMessage(accessor)) {
             String destination = accessor.getDestination();
-            String slotId = destination.replace("/topic/", "");
+            String slotId = destination.replace(SLOT_SUBSCRIPTION_DESTINATION_PREFIX, "");
             if(cacheUtilService.getVerifiedSlotTransaction(slotId) == null) {
                 throw new MessageDeliveryException(ErrorConstants.INVALID_SLOT_ID);
             }
@@ -34,6 +41,6 @@ public class WebSocketChannelInterceptor implements ChannelInterceptor {
         return accessor != null
                 && StompCommand.SUBSCRIBE.equals(accessor.getCommand())
                 && accessor.getDestination() != null
-                && accessor.getDestination().startsWith("/topic/");
+                && accessor.getDestination().startsWith(SLOT_SUBSCRIPTION_DESTINATION_PREFIX);
     }
 }

--- a/signup-service/src/main/java/io/mosip/signup/util/WebSocketChannelInterceptor.java
+++ b/signup-service/src/main/java/io/mosip/signup/util/WebSocketChannelInterceptor.java
@@ -1,0 +1,39 @@
+package io.mosip.signup.util;
+
+import io.mosip.signup.exception.SignUpException;
+import io.mosip.signup.services.CacheUtilService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WebSocketChannelInterceptor implements ChannelInterceptor {
+
+    @Autowired
+    private CacheUtilService cacheUtilService;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        if(isTopicSubscription(accessor)) {
+            String destination = accessor.getDestination();
+            String slotId = destination.replace("/topic/", "");
+            if(cacheUtilService.getVerifiedSlotTransaction(slotId) == null) {
+                throw new SignUpException(ErrorConstants.INVALID_SLOT_ID);
+            }
+        }
+        return message;
+    }
+
+    private boolean isTopicSubscription(StompHeaderAccessor accessor) {
+        return accessor != null
+                && StompCommand.SUBSCRIBE.equals(accessor.getCommand())
+                && accessor.getDestination() != null
+                && accessor.getDestination().startsWith("/topic/");
+    }
+}

--- a/signup-service/src/main/java/io/mosip/signup/util/WebSocketChannelInterceptor.java
+++ b/signup-service/src/main/java/io/mosip/signup/util/WebSocketChannelInterceptor.java
@@ -1,10 +1,10 @@
 package io.mosip.signup.util;
 
-import io.mosip.signup.exception.SignUpException;
 import io.mosip.signup.services.CacheUtilService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
@@ -20,17 +20,17 @@ public class WebSocketChannelInterceptor implements ChannelInterceptor {
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-        if(isTopicSubscription(accessor)) {
+        if(isSlotSubscriptionMessage(accessor)) {
             String destination = accessor.getDestination();
             String slotId = destination.replace("/topic/", "");
             if(cacheUtilService.getVerifiedSlotTransaction(slotId) == null) {
-                throw new SignUpException(ErrorConstants.INVALID_SLOT_ID);
+                throw new MessageDeliveryException(ErrorConstants.INVALID_SLOT_ID);
             }
         }
         return message;
     }
 
-    private boolean isTopicSubscription(StompHeaderAccessor accessor) {
+    private boolean isSlotSubscriptionMessage(StompHeaderAccessor accessor) {
         return accessor != null
                 && StompCommand.SUBSCRIBE.equals(accessor.getCommand())
                 && accessor.getDestination() != null

--- a/signup-service/src/test/java/io/mosip/signup/util/WebSocketChannelInterceptorTest.java
+++ b/signup-service/src/test/java/io/mosip/signup/util/WebSocketChannelInterceptorTest.java
@@ -1,0 +1,57 @@
+package io.mosip.signup.util;
+
+import io.mosip.signup.dto.IdentityVerificationTransaction;
+import io.mosip.signup.exception.SignUpException;
+import io.mosip.signup.services.CacheUtilService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+
+@ExtendWith(MockitoExtension.class)
+public class WebSocketChannelInterceptorTest {
+
+    @InjectMocks
+    private WebSocketChannelInterceptor channelInterceptor;
+
+    @Mock
+    private CacheUtilService cacheUtilService;
+
+    @Test
+    public void websocketSubscribe_withValidSlotId_thenPass() {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+        headerAccessor.setDestination("/topic/slotid");
+        Message<?> message = MessageBuilder.createMessage(new byte[0], headerAccessor.getMessageHeaders());
+        Mockito.when(cacheUtilService.getVerifiedSlotTransaction(Mockito.anyString())).thenReturn(new IdentityVerificationTransaction());
+
+        Assertions.assertDoesNotThrow(() -> channelInterceptor.preSend(message, new MessageChannel() {
+            @Override
+            public boolean send(Message<?> message, long l) {
+                return false;
+            }
+        }));
+    }
+
+    @Test
+    public void websocketSubscribe_withInvalidSlotId_thenThrow() {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+        headerAccessor.setDestination("/topic/slotid");
+        Message<?> message = MessageBuilder.createMessage(new byte[0], headerAccessor.getMessageHeaders());
+        Mockito.when(cacheUtilService.getVerifiedSlotTransaction(Mockito.anyString())).thenReturn(null);
+
+        Assertions.assertThrows(SignUpException.class, () -> channelInterceptor.preSend(message, new MessageChannel() {
+            @Override
+            public boolean send(Message<?> message, long l) {
+                return false;
+            }
+        }));
+    }
+}

--- a/signup-service/src/test/java/io/mosip/signup/util/WebSocketChannelInterceptorTest.java
+++ b/signup-service/src/test/java/io/mosip/signup/util/WebSocketChannelInterceptorTest.java
@@ -1,7 +1,11 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 package io.mosip.signup.util;
 
 import io.mosip.signup.dto.IdentityVerificationTransaction;
-import io.mosip.signup.exception.SignUpException;
 import io.mosip.signup.services.CacheUtilService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -12,6 +16,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.MessageBuilder;
@@ -25,10 +30,12 @@ public class WebSocketChannelInterceptorTest {
     @Mock
     private CacheUtilService cacheUtilService;
 
+    final static private String SLOT_SUBSCRIPTION_DESTINATION_PREFIX = "/topic/";
+
     @Test
     public void websocketSubscribe_withValidSlotId_thenPass() {
         StompHeaderAccessor headerAccessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
-        headerAccessor.setDestination("/topic/slotid");
+        headerAccessor.setDestination(SLOT_SUBSCRIPTION_DESTINATION_PREFIX + "slotid");
         Message<?> message = MessageBuilder.createMessage(new byte[0], headerAccessor.getMessageHeaders());
         Mockito.when(cacheUtilService.getVerifiedSlotTransaction(Mockito.anyString())).thenReturn(new IdentityVerificationTransaction());
 
@@ -41,13 +48,13 @@ public class WebSocketChannelInterceptorTest {
     }
 
     @Test
-    public void websocketSubscribe_withInvalidSlotId_thenThrow() {
+    public void websocketSubscribe_withInvalidSlotId_throwException() {
         StompHeaderAccessor headerAccessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
-        headerAccessor.setDestination("/topic/slotid");
+        headerAccessor.setDestination(SLOT_SUBSCRIPTION_DESTINATION_PREFIX + "slotid");
         Message<?> message = MessageBuilder.createMessage(new byte[0], headerAccessor.getMessageHeaders());
         Mockito.when(cacheUtilService.getVerifiedSlotTransaction(Mockito.anyString())).thenReturn(null);
 
-        Assertions.assertThrows(SignUpException.class, () -> channelInterceptor.preSend(message, new MessageChannel() {
+        Assertions.assertThrows(MessageDeliveryException.class, () -> channelInterceptor.preSend(message, new MessageChannel() {
             @Override
             public boolean send(Message<?> message, long l) {
                 return false;


### PR DESCRIPTION
When using wrong slotId for subscription and error message is send to subscriber and connection is closed.
![Screenshot 2025-01-04 231030](https://github.com/user-attachments/assets/118c24b3-ee00-4702-ba48-66b1a6267796)
