### PR TITLE
[ES-2029] Able to get success response when additional attribute passed in the request body

### DIFF
--- a/signup-service/src/main/resources/application-default.properties
+++ b/signup-service/src/main/resources/application-default.properties
@@ -234,3 +234,6 @@ kafka.consumer.enable-auto-commit=true
 #------------------------------------------ Others ---------------------------------------------------------------------
 logging.level.io.mosip.signup=INFO
 #logging.level.org.springframework.web.client.RestTemplate=INFO
+
+#-----------property set to not allow extra parameters or unknown properties in request body---------
+spring.jackson.deserialization.fail-on-unknown-properties=true

--- a/signup-service/src/main/resources/application-local.properties
+++ b/signup-service/src/main/resources/application-local.properties
@@ -45,3 +45,5 @@ mosip.signup.mock.mandatory-attributes.UPDATE=
 mosip.signup.mock.lang-based-attributes=fullName
 mosip.signup.mock.username.field=phone
 
+#-----------property set to not allow extra parameters or unknown properties in request body---------
+spring.jackson.deserialization.fail-on-unknown-properties=true


### PR DESCRIPTION
Added spring.jackson.deserialization.fail-on-unknown-properties flag in properties file, in order to enable the Wrapper jackson validations 