### PR TITLE
ES-Unused property removed

### DIFF
--- a/signup-service/src/main/resources/signup-identity-verifier-details.json
+++ b/signup-service/src/main/resources/signup-identity-verifier-details.json
@@ -10,8 +10,7 @@
     "logoUrl": "https://avatars.githubusercontent.com/u/39733477?s=200&v=4",
     "processType": "VIDEO",
     "active": true,
-    "retryOnFailure": true,
-    "retryAttempt": 2
+    "retryOnFailure": true
   },
   {
     "id": "mock-identity-verifier2",
@@ -24,7 +23,6 @@
     "logoUrl": "https://avatars.githubusercontent.com/u/39733477?s=200&v=4",
     "processType": "VIDEO",
     "active": true,
-    "retryOnFailure": true,
-    "retryAttempt": 2
+    "retryOnFailure": true
   }
 ]


### PR DESCRIPTION
After the changes of ES-2029 to throw error on unknown properties. The initiate api was failing because of unknown property as this was not defined in the IdentityVerifierDetail.java class. Hence removed the unknown/unused property (retryAttempts)