### PR TITLE
MOSIP-33883 - Added logic to add runtime properties for mock ID plugin to enable pre configured otp

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -57,7 +57,11 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
+<<<<<<< HEAD
 			<version>1.3.3-SNAPSHOT</version>
+=======
+			<version>1.3.2</version>
+>>>>>>> 1fc15de (MOSIP-41339: Automated oauthdetails v3 scenarios (#631))
 		</dependency>
 	</dependencies>
 

--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -57,11 +57,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-<<<<<<< HEAD
 			<version>1.3.3-SNAPSHOT</version>
-=======
-			<version>1.3.2</version>
->>>>>>> 1fc15de (MOSIP-41339: Automated oauthdetails v3 scenarios (#631))
 		</dependency>
 	</dependencies>
 

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testrunner/MosipTestRunner.java
@@ -10,7 +10,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -25,8 +25,8 @@ import com.nimbusds.jose.jwk.RSAKey;
 
 import io.mosip.testrig.apirig.dataprovider.BiometricDataProvider;
 import io.mosip.testrig.apirig.dbaccess.DBManager;
-import io.mosip.testrig.apirig.report.EmailableReport;
 import io.mosip.testrig.apirig.signup.utils.SignupConfigManager;
+import io.mosip.testrig.apirig.signup.utils.SignupConstants;
 import io.mosip.testrig.apirig.signup.utils.SignupUtil;
 import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.apirig.testrunner.ExtractResource;
@@ -34,7 +34,6 @@ import io.mosip.testrig.apirig.testrunner.HealthChecker;
 import io.mosip.testrig.apirig.testrunner.OTPListener;
 import io.mosip.testrig.apirig.utils.AdminTestUtil;
 import io.mosip.testrig.apirig.utils.AuthTestsUtil;
-import io.mosip.testrig.apirig.utils.CertificateGenerationUtil;
 import io.mosip.testrig.apirig.utils.CertsUtil;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.GlobalMethods;
@@ -109,6 +108,13 @@ public class MosipTestRunner {
 				KeycloakUserManager.removeUser();
 				KeycloakUserManager.closeKeycloakInstance();
 			} else {
+				// Mock ID System
+
+				// In mock ID system also the OTP value is hard coded and not configurable.
+				Map<String, Object> additionalPropertiesMap = new HashMap<String, Object>();
+				additionalPropertiesMap.put(SignupConstants.USE_PRE_CONFIGURED_OTP_STRING, SignupConstants.TRUE_STRING);
+				additionalPropertiesMap.put(SignupConstants.PRE_CONFIGURED_OTP_STRING, SignupConstants.ALL_ONE_OTP_STRING);
+				SignupConfigManager.add(additionalPropertiesMap);
 				SignupUtil.getSupportedLanguage();
 				startTestRunner();
 			}

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/utils/SignupConfigManager.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/utils/SignupConfigManager.java
@@ -33,6 +33,8 @@ public class SignupConfigManager extends ConfigManager{
 		init(moduleSpecificPropertiesMap);
 	}
 
-
+	public static void add(Map<String, Object> additionalPropertiesMap) {
+		propertiesMap.putAll(additionalPropertiesMap);
+	}
 
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/utils/SignupConstants.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/utils/SignupConstants.java
@@ -68,5 +68,13 @@ public class SignupConstants {
 	public static final String MOSIP_SIGNUP_IDREPO_MANDATORY_LANGUAGE = "mosip.signup.idrepo.mandatory-language";
 	
 	public static final String JSON_PROPERTY_STRING = "json-property";
+	
+	public static final String USE_PRE_CONFIGURED_OTP_STRING = "usePreConfiguredOtp";
+	
+	public static final String PRE_CONFIGURED_OTP_STRING = "preconfiguredOtp";
+	
+	public static final String TRUE_STRING = "true";
+	
+	public static final String ALL_ONE_OTP_STRING = "111111";
 
 }


### PR DESCRIPTION
- changed latest pom version.
- adding runtime properties for mock ID plugin to enable pre configured otp