### PR TITLE
MOSIP-40258: Standardized XSS Exception Handling in apitest-esignet-signup Module

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.3.2-SNAPSHOT</version>
+			<version>1.3.3-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/AddIdentity.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/AddIdentity.java
@@ -38,6 +38,7 @@ import io.mosip.testrig.apirig.utils.KernelAuthentication;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
 import io.mosip.testrig.apirig.utils.RestClient;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class AddIdentity extends SignupUtil implements ITest {
@@ -85,7 +86,7 @@ public class AddIdentity extends SignupUtil implements ITest {
 	 * @throws Exception 
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws Exception {
+	public void test(TestCaseDTO testCaseDTO) throws Exception, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseDTO = SignupUtil.isTestCaseValidForTheExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/GetWithParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/GetWithParam.java
@@ -34,6 +34,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class GetWithParam extends SignupUtil implements ITest {
@@ -82,7 +83,7 @@ public class GetWithParam extends SignupUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseDTO = SignupUtil.isTestCaseValidForTheExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/PatchWithPathParamsAndBody.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/PatchWithPathParamsAndBody.java
@@ -30,6 +30,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class PatchWithPathParamsAndBody extends SignupUtil implements ITest {
@@ -77,7 +78,7 @@ public class PatchWithPathParamsAndBody extends SignupUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseDTO = SignupUtil.isTestCaseValidForTheExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/PostWithAutogenIdWithOtpGenerate.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/PostWithAutogenIdWithOtpGenerate.java
@@ -32,6 +32,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class PostWithAutogenIdWithOtpGenerate extends SignupUtil implements ITest {
@@ -83,7 +84,7 @@ public class PostWithAutogenIdWithOtpGenerate extends SignupUtil implements ITes
 	 */
 	@Test(dataProvider = "testcaselist")
 	public void test(TestCaseDTO testCaseDTO)
-			throws AuthenticationTestException, AdminTestException, NumberFormatException, InterruptedException {
+			throws AuthenticationTestException, AdminTestException, NumberFormatException, InterruptedException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseDTO = SignupUtil.isTestCaseValidForTheExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/PostWithOnlyPathParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/PostWithOnlyPathParam.java
@@ -33,6 +33,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class PostWithOnlyPathParam extends SignupUtil implements ITest {
@@ -80,7 +81,7 @@ public class PostWithOnlyPathParam extends SignupUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseDTO = SignupUtil.isTestCaseValidForTheExecution(testCaseDTO);
 		String[] templateFields = testCaseDTO.getTemplateFields();

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/PutWithPathParamsAndBody.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/PutWithPathParamsAndBody.java
@@ -33,6 +33,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class PutWithPathParamsAndBody extends SignupUtil implements ITest {
@@ -80,7 +81,7 @@ public class PutWithPathParamsAndBody extends SignupUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseDTO = SignupUtil.isTestCaseValidForTheExecution(testCaseDTO);
 		String[] templateFields = testCaseDTO.getTemplateFields();

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/SimplePost.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/SimplePost.java
@@ -33,6 +33,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class SimplePost extends SignupUtil implements ITest {
@@ -81,7 +82,7 @@ public class SimplePost extends SignupUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseDTO = SignupUtil.isTestCaseValidForTheExecution(testCaseDTO);
 		auditLogCheck = testCaseDTO.isAuditLogCheck();

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/SimplePostForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/SimplePostForAutoGenId.java
@@ -34,6 +34,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class SimplePostForAutoGenId extends SignupUtil implements ITest {
@@ -86,7 +87,7 @@ public class SimplePostForAutoGenId extends SignupUtil implements ITest {
 	 */
 	@Test(dataProvider = "testcaselist")
 	public void test(TestCaseDTO testCaseDTO)
-			throws AuthenticationTestException, AdminTestException, NoSuchAlgorithmException {
+			throws AuthenticationTestException, AdminTestException, NoSuchAlgorithmException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseDTO = SignupUtil.isTestCaseValidForTheExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/SimplePostForAutoGenIdForUrlEncoded.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/SimplePostForAutoGenIdForUrlEncoded.java
@@ -33,6 +33,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class SimplePostForAutoGenIdForUrlEncoded extends SignupUtil implements ITest {
@@ -82,7 +83,7 @@ public class SimplePostForAutoGenIdForUrlEncoded extends SignupUtil implements I
 	 */
 	@Test(dataProvider = "testcaselist")
 	public void test(TestCaseDTO testCaseDTO)
-			throws AuthenticationTestException, AdminTestException, NoSuchAlgorithmException {
+			throws AuthenticationTestException, AdminTestException, NoSuchAlgorithmException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseDTO = SignupUtil.isTestCaseValidForTheExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/WebScocketConnection.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/WebScocketConnection.java
@@ -30,6 +30,7 @@ import io.mosip.testrig.apirig.utils.AdminTestUtil;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.GlobalMethods;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.mosip.testrig.apirig.utils.WebSocketClientUtil;
 import io.restassured.response.Response;
 
@@ -84,7 +85,7 @@ public class WebScocketConnection extends SignupUtil implements ITest {
 	 */
 	@Test(dataProvider = "testcaselist")
 	public void test(TestCaseDTO testCaseDTO)
-			throws AuthenticationTestException, AdminTestException, NumberFormatException, InterruptedException {
+			throws AuthenticationTestException, AdminTestException, NumberFormatException, InterruptedException, SecurityXSSException {
 
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseDTO = SignupUtil.isTestCaseValidForTheExecution(testCaseDTO);


### PR DESCRIPTION
Integrated SecurityXSSException in the apitest-esignet-signup module to standardize XSS-related error handling. This ensures consistent exception throwing across the application wherever XSS protection checks fail. Improves security and maintainability by centralizing exception logic.