### PR TITLE
MOSIP-28246: Removed unused variables from esignet-signup module 

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/PostWithAutogenIdWithOtpGenerate.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/PostWithAutogenIdWithOtpGenerate.java
@@ -27,7 +27,6 @@ import io.mosip.testrig.apirig.signup.utils.SignupUtil;
 import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.apirig.testrunner.HealthChecker;
 import io.mosip.testrig.apirig.utils.AdminTestException;
-//import io.mosip.testrig.apirig.utils.AdminTestUtil;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/SimplePostForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/SimplePostForAutoGenId.java
@@ -110,7 +110,6 @@ public class SimplePostForAutoGenId extends SignupUtil implements ITest {
 			inputJson = getJsonFromTemplate(testCaseDTO.getInput(), testCaseDTO.getInputTemplate());
 		}
 
-//		String outputJson = getJsonFromTemplate(testCaseDTO.getOutput(), testCaseDTO.getOutputTemplate());
 
 		if (testCaseDTO.getTemplateFields() != null && templateFields.length > 0) {
 			ArrayList<JSONObject> inputtestCases = AdminTestUtil.getInputTestCase(testCaseDTO);

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/WebScocketConnection.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/WebScocketConnection.java
@@ -26,7 +26,6 @@ import io.mosip.testrig.apirig.signup.utils.SignupConfigManager;
 import io.mosip.testrig.apirig.signup.utils.SignupUtil;
 import io.mosip.testrig.apirig.testrunner.HealthChecker;
 import io.mosip.testrig.apirig.utils.AdminTestException;
-//import io.mosip.testrig.apirig.utils.AdminTestUtil;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.GlobalMethods;


### PR DESCRIPTION
Commented out unused variables in the esignet-signup module to improve code cleanliness and maintainability. Identified via static code analysis. No functional changes made.