### PR TITLE
[ES-2358] Call csrf/token in signup-ui & use the token in every post api call - Fixed

### DIFF
--- a/signup-ui/src/pages/shared/service.ts
+++ b/signup-ui/src/pages/shared/service.ts
@@ -1,5 +1,6 @@
 import { ApiService } from "~services/api.service";
 import {
+  CsrfTokenResponseDto,
   GenerateChallengeRequestDto,
   IdentityVerificationStatus,
   IdentityVerificationStatusResponseDto,
@@ -30,6 +31,12 @@ export const getCookie = (key: string): string | any => {
 
 export const getSettings = async (): Promise<SettingsDto> => {
   return ApiService.get<SettingsDto>("/settings").then(({ data }) => data);
+};
+
+export const getCsrfToken = async (): Promise<CsrfTokenResponseDto> => {
+  return ApiService.get("/csrf/token").then(({ data }) => {
+    return data;
+  });
 };
 
 export const generateChallenge = async (

--- a/signup-ui/src/services/api.service.ts
+++ b/signup-ui/src/services/api.service.ts
@@ -27,6 +27,33 @@ export const ApiService = axios.create({
   baseURL: API_BASE_URL,
 });
 
+const AxiosInstance = axios.create({
+  baseURL: API_BASE_URL,
+  withCredentials: true,
+});
+
+let cachedCsrfToken: string | null = null;
+
+ApiService.interceptors.request.use(
+  async (config) => {
+    try {
+      if (config.method?.toLowerCase() === "post") {
+        if (!cachedCsrfToken) {
+          const { data } = await AxiosInstance.get("/csrf/token");
+          cachedCsrfToken = data.token; 
+        }
+        config.headers["X-XSRF-TOKEN"] = cachedCsrfToken;
+      }
+    } catch (error) {
+      throw error; 
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
 export const setupResponseInterceptor = (navigate: NavigateFunction) => {
   ApiService.interceptors.response.use(
     (response) => response,

--- a/signup-ui/src/typings/types.ts
+++ b/signup-ui/src/typings/types.ts
@@ -168,6 +168,12 @@ export type SettingsDto = BaseResponseDto & {
   errors: Error[] | null;
 };
 
+export type CsrfTokenResponseDto = {
+  token: string;
+  parameterName: string;
+  headerName: string;
+};
+
 const ChallengeGenerationPurposes = ["REGISTRATION", "RESET_PASSWORD"] as const;
 
 export type ChallengeGenerationPurpose =


### PR DESCRIPTION
<img width="959" alt="Signup fix2" src="https://github.com/user-attachments/assets/11a21cfc-a03e-471a-864e-1fa04d615a33" />
