### PR TITLE
[ES-2358] Call csrf/token in signup-ui & use the token in every post …

### DIFF
--- a/signup-ui/src/pages/shared/service.ts
+++ b/signup-ui/src/pages/shared/service.ts
@@ -1,4 +1,4 @@
-import { ApiService } from "~services/api.service";
+import { ApiService, AxiosInstance } from "~services/api.service";
 import {
   GenerateChallengeRequestDto,
   IdentityVerificationStatus,
@@ -30,6 +30,12 @@ export const getCookie = (key: string): string | any => {
 
 export const getSettings = async (): Promise<SettingsDto> => {
   return ApiService.get<SettingsDto>("/settings").then(({ data }) => data);
+};
+
+export const getCsrfToken = async (): Promise<string> => {
+  return AxiosInstance.get("/csrf/token").then(({ data }) => {
+    return data.token;
+  });
 };
 
 export const generateChallenge = async (


### PR DESCRIPTION
…api call - Fixed (#645)

* [ES-2358] Added X-XSRF-TOKEN header in post requests



* Updated interceptor to save csrf in session storage



* Updated getCsrfToken function



---------

[ES-2358]: https://mosip.atlassian.net/browse/ES-2358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ