### PR TITLE
Removing each step status info from Extent Report

### DIFF
--- a/ui-test/src/main/java/utils/ExtentReportManager.java
+++ b/ui-test/src/main/java/utils/ExtentReportManager.java
@@ -162,9 +162,13 @@ public class ExtentReportManager {
 	}
 
 	public static void logStep(String message) {
+	    if (message != null && message.trim().startsWith("ℹ️ Step completed successfully:")) {
+	        return;
+	    }
 		ExtentTest test = testThread.get();
 		if (test != null) {
 			test.info(message);
+	    } else {
 			LOGGER.warn("logStep called but no test is active: {}", message);
 		}
 	}


### PR DESCRIPTION
Removing each step status info from Extent Report, As we are capturing the details with the actions. so Duplicate details are appearing in the report. 