### PR TITLE
[ES-2687] Removed hardcoded zero-validation from signup-ui.

### DIFF
--- a/signup-ui/src/pages/shared/validation.ts
+++ b/signup-ui/src/pages/shared/validation.ts
@@ -5,10 +5,6 @@ import { SettingsDto } from "~typings/types";
 export const validateUsername = (settings: SettingsDto) =>
   yup
     .string()
-    .matches(/^[^0].*$/, {
-      message: "username_lead_zero_validation",
-      excludeEmptyString: true,
-    })
     .test("isUsernameValid", "username_validation", (value) => {
       if (value === "") return true;
       return new RegExp(settings.response.configs["identifier.pattern"]).test(


### PR DESCRIPTION
Now the validation for number will entirely depend upon the regex set in the configuration. 
<img width="1919" height="917" alt="image" src="https://github.com/user-attachments/assets/0cbfebe5-c785-4d60-afbd-9ae14298eb1a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated username validation to permit usernames beginning with numeric characters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->