### PR TITLE
[ES-2723] Fix - Back button on Reset Password page not navigating to Forgot Password page

### DIFF
--- a/signup-ui/src/pages/ResetPasswordPage/Otp/Otp.tsx
+++ b/signup-ui/src/pages/ResetPasswordPage/Otp/Otp.tsx
@@ -318,7 +318,7 @@ export const Otp = ({ methods, settings }: OtpProps) => {
           <button
             type="button"
             onClick={handleBack}
-            className="absolute left-0 ml-8 cursor-pointer"
+            className="absolute left-0 ml-8"
             aria-label="Go back"
           >
             <Icons.back

--- a/signup-ui/src/pages/ResetPasswordPage/Otp/Otp.tsx
+++ b/signup-ui/src/pages/ResetPasswordPage/Otp/Otp.tsx
@@ -315,12 +315,17 @@ export const Otp = ({ methods, settings }: OtpProps) => {
     <Step>
       <StepHeader className="px-0 sm:px-[18px] sm:pb-[25px] sm:pt-[33px]">
         <StepTitle className="relative flex w-full items-center justify-center gap-x-4 text-base font-semibold">
-          <Icons.back
-            id="back-button"
-            name="back-button"
-            className="absolute left-0 ml-8 cursor-pointer"
+          <button
+            type="button"
             onClick={handleBack}
-          />
+            className="absolute left-0 ml-8 cursor-pointer"
+            aria-label="Go back"
+          >
+            <Icons.back
+              id="back-button"
+              name="back-button"
+            />
+          </button>
           <div className="w-full text-center text-[22px] font-semibold">
             {t("otp_header")}
           </div>

--- a/signup-ui/src/pages/ResetPasswordPage/ResetPassword/ResetPassword.tsx
+++ b/signup-ui/src/pages/ResetPasswordPage/ResetPassword/ResetPassword.tsx
@@ -130,12 +130,14 @@ export const ResetPassword = ({ methods, settings }: ResetPasswordProps) => {
       <Step>
         <StepHeader>
           <StepTitle className="relative flex w-full items-center justify-center gap-x-4 text-[26px] font-semibold">
-            <Icons.back
-              id="back-button"
-              name="back-button"
-              className="absolute left-0 cursor-pointer"
+            <button
+              type="button"
               onClick={handleBack}
-            />
+              className="absolute left-0 ml-8 cursor-pointer"
+              aria-label="Go back"
+            >
+              <Icons.back id="back-button" name="back-button" />
+            </button>
             <div className="text-center font-semibold tracking-normal">
               {t("reset_password")}
             </div>

--- a/signup-ui/src/pages/ResetPasswordPage/ResetPassword/ResetPassword.tsx
+++ b/signup-ui/src/pages/ResetPasswordPage/ResetPassword/ResetPassword.tsx
@@ -133,7 +133,7 @@ export const ResetPassword = ({ methods, settings }: ResetPasswordProps) => {
             <button
               type="button"
               onClick={handleBack}
-              className="absolute left-0 ml-8 cursor-pointer"
+              className="absolute left-0 ml-8"
               aria-label="Go back"
             >
               <Icons.back id="back-button" name="back-button" />

--- a/signup-ui/src/pages/SignUpPage/Otp/Otp.tsx
+++ b/signup-ui/src/pages/SignUpPage/Otp/Otp.tsx
@@ -310,12 +310,17 @@ export const Otp = ({ methods, settings }: OtpProps) => {
     <Step>
       <StepHeader className="px-0 sm:px-[18px] sm:pb-[25px] sm:pt-[33px]">
         <StepTitle className="relative flex w-full items-center justify-center gap-x-4 text-base font-semibold">
-          <Icons.back
-            id="back-button"
-            name="back-button"
-            className="absolute left-0 ml-8 cursor-pointer"
+          <button
+            type="button"
             onClick={handleBack}
-          />
+            className="absolute left-0 ml-8 cursor-pointer"
+            aria-label="Go back"
+          >
+            <Icons.back
+              id="back-button"
+              name="back-button"
+            />
+          </button>
           <div className="w-full text-center text-[22px] font-semibold">
             {t("otp_header")}
           </div>

--- a/signup-ui/src/pages/SignUpPage/Otp/Otp.tsx
+++ b/signup-ui/src/pages/SignUpPage/Otp/Otp.tsx
@@ -313,7 +313,7 @@ export const Otp = ({ methods, settings }: OtpProps) => {
           <button
             type="button"
             onClick={handleBack}
-            className="absolute left-0 ml-8 cursor-pointer"
+            className="absolute left-0 ml-8"
             aria-label="Go back"
           >
             <Icons.back


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Back navigation controls in the sign-up and password-reset flows have been updated to use proper button elements with descriptive aria-labels ("Go back"), improving keyboard and screen-reader accessibility while preserving existing click behavior and layout.
  
* **Chores**
  * Minor layout adjustment applied to ensure consistent spacing for the updated controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->