### PR TITLE
[ES-2764] Removed afterburner module from object mapper

### DIFF
--- a/signup-service/src/main/java/io/mosip/signup/config/Config.java
+++ b/signup-service/src/main/java/io/mosip/signup/config/Config.java
@@ -8,7 +8,6 @@ package io.mosip.signup.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import io.mosip.signup.services.CacheUtilService;
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
@@ -60,7 +59,6 @@ public class Config {
     @Bean
     public ObjectMapper objectMapper() {
         return JsonMapper.builder()
-                .addModule(new AfterburnerModule())
                 .addModule(new JavaTimeModule())
                 .build();
     }


### PR DESCRIPTION
After burner module is not recommended to be used in springboot 3. By default that level of access is not enabled in java 21 and most the performance benefit do not apply anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal application configuration to remove an optimization module.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->