### PR TITLE
[ES-2765] [ES-2766] [ES-2767] identity verification flow from signup itself

### DIFF
--- a/signup-service/src/main/resources/application-default.properties
+++ b/signup-service/src/main/resources/application-default.properties
@@ -193,6 +193,25 @@ mosip.signup.identifier.min-length=8
 mosip.signup.identifier.max-length=9
 mosip.signup.identifier.name=phone
 
+mosip.signup.rp.scopes='openid'
+mosip.signup.rp.acr_values='mosip:idp:acr:generated-code%20mosip:idp:acr:password%20mosip:idp:acr:linked-wallet%20mosip:idp:acr:knowledge'
+mosip.signup.rp.claims=''
+mosip.signup.rp.expiry_time=600
+mosip.signup.rp.redirect_delay=10
+mosip.signup.rp.ui.config = { \
+  'client_id': '${mosip.signup.oauth.client-id}', \
+  'redirect_uri_verification': '${mosip.signup.oauth.redirect-uri}', \
+  'redirect_uri_signin': '${mosip.esignet.domain.url}/login', \
+  'redirect_uri_consent': '${mosip.esignet.domain.url}/consent', \
+  'authorization_endpoint': '${mosip.esignet.domain.url}/authorize', \
+  'response_type': 'code', \
+  'scope': '${mosip.signup.rp.scopes}', \
+  'claims': '${mosip.signup.rp.claims}', \
+  'acr_values': '${mosip.signup.rp.acr_values}', \
+  'expiry_time': ${mosip.signup.rp.expiry_time}, \
+  'redirect_delay': ${mosip.signup.rp.redirect_delay}, \
+}
+
 # Only after current challenge timeout we should enable resend in the UI.
 # In this case timeout and resend-delay should be same always.
 mosip.signup.ui.config.key-values={\
@@ -227,6 +246,7 @@ mosip.signup.ui.config.key-values={\
 'signup.oauth-client-id': '${mosip.signup.oauth.client-id}', \
 'identity-verification.redirect-url': '${mosip.signup.oauth.redirect-uri}', \
 'broswer.minimum-version': ${mosip.signup.minimum-browser-version}, \
+'rp.config': ${mosip.signup.rp.ui.config}, \
 'esignet-consent.redirect-url': '${mosip.esignet.domain.url}/consent' }
 
 ## ----------------------------- Notification templates -----------------------------------------------------------------------------

--- a/signup-ui/public/locales/en.json
+++ b/signup-ui/public/locales/en.json
@@ -1,6 +1,8 @@
 {
   "logo_alt": "eSignet Signup",
   "register": "Register",
+  "verify_identity": "eKYC Verification",
+  "proceed_to_verification": "Proceed to eKYC Verification",
   "landing_page_title": "Oops! The page you are looking for does not exist.",
   "landing_page_description": "Please try navigating using the options below.",
   "enter_your_number": "Please enter your mobile number to continue",

--- a/signup-ui/public/locales/en.json
+++ b/signup-ui/public/locales/en.json
@@ -205,7 +205,8 @@
   "identity_verification_status": {
     "successful": {
       "title": "Verification Successful!",
-      "description": "Please wait while we finalize the process"
+      "description": "Please wait while we finalize the process",
+      "countdown": "Redirecting in <CountDownSpan>{{countDown}}</CountDownSpan>"
     },
     "failed": {
       "title": "Verification Unsuccessful!",

--- a/signup-ui/public/locales/km.json
+++ b/signup-ui/public/locales/km.json
@@ -1,6 +1,8 @@
 {
   "logo_alt": "និមិត្តសញ្ញាអង្គភាព",
   "register": "បង្កើតគណនី",
+  "verify_identity": "ការផ្ទៀងផ្ទាត់ eKYC",
+  "proceed_to_verification": "បន្តទៅការផ្ទៀងផ្ទាត់ eKYC",
   "landing_page_title": "សូមអភ័យទោស! ទំព័រដែលអ្នកស្វែងរកមិនមាននោះទេ។",
   "landing_page_description": "អ្នកអាចស្វែងរកដោយប្រើជម្រើសខាងក្រោម។",
   "enter_your_number": "សូមបញ្ចូលលេខទូរសព្ទរបស់អ្នកដើម្បីបន្ត",

--- a/signup-ui/public/locales/km.json
+++ b/signup-ui/public/locales/km.json
@@ -204,8 +204,9 @@
   },
   "identity_verification_status": {
     "successful": {
-      "title": "ការផ្ទៀងផ្ទាត់បានជោគជ័យ!",
-      "description": "សូមរង់ចាំខណៈពេលដែលយើងបញ្ចប់ដំណើរការ"
+      "title": "ផ្ទៀងផ្ទាត់ដោយជោគជ័យ!",
+      "description": "សូមរង់ចាំខណៈពេលយើងបញ្ចប់ដំណើរការ",
+      "countdown": "ការបញ្ជូនបន្តក្នុងរយៈពេល <CountDownSpan>{{countDown}}</CountDownSpan>"
     },
     "failed": {
       "title": "ការផ្ទៀងផ្ទាត់មិនបានជោគជ័យ!",

--- a/signup-ui/src/App.css
+++ b/signup-ui/src/App.css
@@ -408,6 +408,9 @@ body {
   @apply text-center text-gray-500;
 }
 
+.redirect_countdown {
+  @apply text-center text-gray-500;
+}
 .status__btn {
   @apply my-4 h-16 w-full;
 }

--- a/signup-ui/src/components/session-alert.tsx
+++ b/signup-ui/src/components/session-alert.tsx
@@ -77,7 +77,7 @@ export const SessionAlert = ({
   const handleReturnToLogin = (e: any) => {
     e.preventDefault();
     window.location.href = getSignInRedirectURLV2(
-      settings?.response.configs["signin.redirect-url"],
+      settings?.response.configs["rp.config"].redirect_uri_signin,
       fromSignInHash,
       search,
       "/signup"

--- a/signup-ui/src/pages/EkycVerificationPage/EkycVerificationPage.tsx
+++ b/signup-ui/src/pages/EkycVerificationPage/EkycVerificationPage.tsx
@@ -122,31 +122,6 @@ export const EkycVerificationPage = ({
       searchParams.has("code") &&
       searchParams.has("ui_locales");
 
-    const stateValue = searchParams.get("state");
-    if (stateValue && stateValue !== "") {
-      // checking state data from local storage
-      // if state data is present then only authorize the user
-      const stateData = getStateData(stateValue);
-      if (stateData) {
-        authorizeUser({
-          state: stateValue,
-          redirect_uri: stateData.redirectUrl,
-          scope: stateData.scope,
-          acr_values: stateData.acrValues,
-          claims: stateData.claims,
-          ui_locales: stateData.uiLocales,
-        });
-      }
-    }
-
-    // Authorize user if id_token_hint is present in query params
-    if (searchParams.has("id_token_hint")) {
-      authorizeUser({
-        state: stateValue,
-        id_token_hint: searchParams.get("id_token_hint") ?? "",
-      });
-    }
-
     if (hasRequiredParams) {
       setHashCode({
         state: searchParams.get("state") ?? "",
@@ -176,6 +151,30 @@ export const EkycVerificationPage = ({
         },
       });
     } else {
+      const stateValue = searchParams.get("state");
+      if (stateValue && stateValue !== "") {
+        // checking state data from local storage
+        // if state data is present then only authorize the user
+        const stateData = getStateData(stateValue);
+        if (stateData) {
+          authorizeUser({
+            state: stateValue,
+            redirect_uri: stateData.redirectUrl,
+            scope: stateData.scope,
+            acr_values: stateData.acrValues,
+            claims: stateData.claims,
+            ui_locales: stateData.uiLocales,
+          });
+        }
+      }
+
+      // Authorize user if id_token_hint is present in query params
+      if (searchParams.has("id_token_hint")) {
+        authorizeUser({
+          state: stateValue,
+          id_token_hint: searchParams.get("id_token_hint") ?? "",
+        });
+      }
       navigateToLandingPage();
     }
   }, [settings]);
@@ -193,7 +192,10 @@ export const EkycVerificationPage = ({
   const cancelAlertPopoverComp = (cancelProp: CancelPopup) => {
     const handleDismiss = () => {
       window.onbeforeunload = null;
-      window.location.href = `${rpConfig?.redirect_uri_consent}?key=${
+      const url = getStateData(searchParams.get("state") || "")
+        ? window.location.origin
+        : rpConfig?.redirect_uri_consent;
+      window.location.href = `${url}?key=${
         searchParams.get("state") || ""
       }&error=dismiss`;
     };
@@ -210,8 +212,11 @@ export const EkycVerificationPage = ({
 
   const handleDismiss = (params: any) => {
     window.onbeforeunload = null;
+    const url = getStateData(searchParams.get("state") || "")
+      ? window.location.origin
+      : rpConfig?.redirect_uri_consent;
     const urlSearchParams = new URLSearchParams(params).toString();
-    window.location.href = `${rpConfig?.redirect_uri_consent}?${urlSearchParams}`;
+    window.location.href = `${url}?${urlSearchParams}`;
   };
 
   const defaultProps: DefaultEkyVerificationProp = {

--- a/signup-ui/src/pages/EkycVerificationPage/EkycVerificationPage.tsx
+++ b/signup-ui/src/pages/EkycVerificationPage/EkycVerificationPage.tsx
@@ -44,6 +44,8 @@ export const EkycVerificationPage = ({
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
 
+  const rpConfig = settings?.response?.configs["rp.config"];
+
   const {
     step,
     criticalError,
@@ -80,11 +82,11 @@ export const EkycVerificationPage = ({
    * @param queryParam Query parameters to include in the authorization URL
    */
   const authorizeUser = (queryParam: any = {}) => {
-    const clientId = settings?.response?.configs["signup.oauth-client-id"];
-    const authorizeURI =
-      settings?.response?.configs["signin.authorization-url"];
-    const identityVerificationRedirectURI =
-      settings?.response?.configs["identity-verification.redirect-url"];
+    const clientId = rpConfig?.client_id;
+    const authorizeURI = rpConfig?.authorization_endpoint;
+    const identityVerificationRedirectURI = rpConfig?.redirect_uri_verification;
+    const scope = rpConfig?.scope;
+    const responseType = rpConfig?.response_type;
 
     const uiLocales =
       searchParams.get("ui_locales") ??
@@ -96,13 +98,14 @@ export const EkycVerificationPage = ({
       state: queryParam.state ?? "",
       redirect_uri:
         queryParam.redirect_uri ?? identityVerificationRedirectURI ?? "",
-      scope: queryParam.scope ?? "openid",
-      response_type: "code",
+      scope: queryParam.scope ?? scope ?? "openid",
+      response_type: responseType ?? "code",
       ui_locales: uiLocales,
       ...(queryParam.acr_values && { acr_values: queryParam.acr_values }),
       ...(queryParam.claims && { claims: queryParam.claims }),
       ...(queryParam.id_token_hint && {
         id_token_hint: queryParam.id_token_hint,
+        acr_values: "mosip:idp:acr:id-token",
       }),
     };
 
@@ -190,9 +193,9 @@ export const EkycVerificationPage = ({
   const cancelAlertPopoverComp = (cancelProp: CancelPopup) => {
     const handleDismiss = () => {
       window.onbeforeunload = null;
-      window.location.href = `${settings?.response?.configs[
-        "esignet-consent.redirect-url"
-      ]}?key=${searchParams.get("state") || ""}&error=dismiss`;
+      window.location.href = `${rpConfig?.redirect_uri_consent}?key=${
+        searchParams.get("state") || ""
+      }&error=dismiss`;
     };
     return (
       cancelProp.cancelButton && (
@@ -205,9 +208,16 @@ export const EkycVerificationPage = ({
     );
   };
 
+  const handleDismiss = (params: any) => {
+    window.onbeforeunload = null;
+    const urlSearchParams = new URLSearchParams(params).toString();
+    window.location.href = `${rpConfig?.redirect_uri_consent}?${urlSearchParams}`;
+  };
+
   const defaultProps: DefaultEkyVerificationProp = {
     settings: settings?.response,
     cancelPopup: cancelAlertPopoverComp,
+    handleDismiss: handleDismiss,
   };
 
   const getEkycVerificationStepContent = (step: EkycVerificationStep) => {
@@ -215,7 +225,7 @@ export const EkycVerificationPage = ({
       case EkycVerificationStep.VerificationSteps:
         return <VerificationSteps {...defaultProps} />;
       case EkycVerificationStep.LoadingScreen:
-        return <LoadingScreen />;
+        return <LoadingScreen handleDismiss={handleDismiss} />;
       case EkycVerificationStep.KycProviderList:
         return <KycProviderList {...defaultProps} />;
       case EkycVerificationStep.TermsAndCondition:
@@ -256,7 +266,9 @@ export const EkycVerificationPage = ({
           "invalid_transaction",
           "identifier_already_registered",
           "grant_exchange_failed",
-        ].includes(criticalError.errorCode) && <EkycVerificationPopover />}
+        ].includes(criticalError.errorCode) && (
+          <EkycVerificationPopover handleDismiss={handleDismiss} />
+        )}
 
       <Form {...methods}>
         <form noValidate>{getEkycVerificationStepContent(step)}</form>

--- a/signup-ui/src/pages/EkycVerificationPage/EkycVerificationPage.tsx
+++ b/signup-ui/src/pages/EkycVerificationPage/EkycVerificationPage.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect } from "react";
 import { useForm } from "react-hook-form";
-import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { Form } from "~components/ui/form";
+import { getStateData } from "~utils/identityVerificationUtil";
 import { useKycProvidersList } from "~pages/shared/mutations";
 import {
   CancelPopup,
@@ -41,9 +41,8 @@ interface EkycVerificationPageProps {
 export const EkycVerificationPage = ({
   settings,
 }: EkycVerificationPageProps) => {
-  const { t } = useTranslation();
   const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
 
   const {
     step,
@@ -76,11 +75,74 @@ export const EkycVerificationPage = ({
     navigate("/");
   };
 
+  /**
+   * Authorizes the user by constructing the authorization URL with necessary query parameters
+   * @param queryParam Query parameters to include in the authorization URL
+   */
+  const authorizeUser = (queryParam: any = {}) => {
+    const clientId = settings?.response?.configs["signup.oauth-client-id"];
+    const authorizeURI =
+      settings?.response?.configs["signin.authorization-url"];
+    const identityVerificationRedirectURI =
+      settings?.response?.configs["identity-verification.redirect-url"];
+
+    const uiLocales =
+      searchParams.get("ui_locales") ??
+      queryParam.ui_locales ??
+      (window as any)?._env_?.DEFAULT_LANG;
+
+    const paramObj = {
+      client_id: clientId ?? "",
+      state: queryParam.state ?? "",
+      redirect_uri:
+        queryParam.redirect_uri ?? identityVerificationRedirectURI ?? "",
+      scope: queryParam.scope ?? "openid",
+      response_type: "code",
+      ui_locales: uiLocales,
+      ...(queryParam.acr_values && { acr_values: queryParam.acr_values }),
+      ...(queryParam.claims && { claims: queryParam.claims }),
+      ...(queryParam.id_token_hint && {
+        id_token_hint: queryParam.id_token_hint,
+      }),
+    };
+
+    const redirectParams = new URLSearchParams(paramObj).toString();
+
+    const redirectURI = `${authorizeURI}?${redirectParams}`;
+
+    window.location.replace(redirectURI);
+  };
+
   useEffect(() => {
     const hasRequiredParams =
       searchParams.has("state") &&
       searchParams.has("code") &&
       searchParams.has("ui_locales");
+
+    const stateValue = searchParams.get("state");
+    if (stateValue && stateValue !== "") {
+      // checking state data from local storage
+      // if state data is present then only authorize the user
+      const stateData = getStateData(stateValue);
+      if (stateData) {
+        authorizeUser({
+          state: stateValue,
+          redirect_uri: stateData.redirectUrl,
+          scope: stateData.scope,
+          acr_values: stateData.acrValues,
+          claims: stateData.claims,
+          ui_locales: stateData.uiLocales,
+        });
+      }
+    }
+
+    // Authorize user if id_token_hint is present in query params
+    if (searchParams.has("id_token_hint")) {
+      authorizeUser({
+        state: stateValue,
+        id_token_hint: searchParams.get("id_token_hint") ?? "",
+      });
+    }
 
     if (hasRequiredParams) {
       setHashCode({
@@ -110,30 +172,6 @@ export const EkycVerificationPage = ({
           }
         },
       });
-    } else if (searchParams.has("id_token_hint")) {
-      const authorizeURI = settings?.response?.configs["signin.authorization-url"];
-      const clientIdURI = settings?.response?.configs["signup.oauth-client-id"];
-      const identityVerificationRedirectURI =
-        settings?.response?.configs["identity-verification.redirect-url"];
-      const urlObj = new URL(window.location.href);
-      const state = urlObj.searchParams.get("state");
-
-      const paramObj = {
-        state: state ?? "",
-        client_id: clientIdURI ?? "",
-        redirect_uri: identityVerificationRedirectURI ?? "",
-        scope: "openid",
-        response_type: "code",
-        id_token_hint: searchParams.get("id_token_hint") ?? "",
-        ui_locales:
-          searchParams.get("ui_locales") ?? (window as any)._env_.DEFAULT_LANG,
-      };
-
-      const redirectParams = new URLSearchParams(paramObj).toString();
-
-      const redirectURI = `${authorizeURI}?${redirectParams}`;
-
-      window.location.replace(redirectURI);
     } else {
       navigateToLandingPage();
     }

--- a/signup-ui/src/pages/EkycVerificationPage/EkycVerificationPopover.tsx
+++ b/signup-ui/src/pages/EkycVerificationPage/EkycVerificationPopover.tsx
@@ -11,7 +11,6 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "~components/ui/alert-dialog";
-import { useSettings } from "~pages/shared/queries";
 
 import {
   criticalErrorSelector,
@@ -19,10 +18,13 @@ import {
   useEkycVerificationStore,
 } from "./useEkycVerificationStore";
 
-export const EkycVerificationPopover = () => {
+export const EkycVerificationPopover = ({
+  handleDismiss,
+}: {
+  handleDismiss: (args: { key: string; error: string }) => void;
+}) => {
   const { t } = useTranslation();
 
-  const { data: settings } = useSettings();
   const { criticalError, hashCode } = useEkycVerificationStore(
     useCallback(
       (state) => ({
@@ -35,10 +37,10 @@ export const EkycVerificationPopover = () => {
 
   const handleAction = (e: any) => {
     e.preventDefault();
-    window.onbeforeunload = null;
-    window.location.href = `${settings?.response?.configs[
-      "esignet-consent.redirect-url"
-    ]}?key=${hashCode?.state || ""}&error=${criticalError?.errorCode}`;
+    handleDismiss({
+      key: hashCode?.state || "",
+      error: criticalError?.errorCode || "",
+    });
   };
 
   return (

--- a/signup-ui/src/pages/EkycVerificationPage/IdentityVerificationStatus/IdentityVerificationStatus.tsx
+++ b/signup-ui/src/pages/EkycVerificationPage/IdentityVerificationStatus/IdentityVerificationStatus.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import { useLocation, useNavigate } from "react-router-dom";
 
+import { ROOT_ROUTE } from "~constants/routes";
 import { useIdentityVerificationStatus } from "~pages/shared/queries";
 import {
   DefaultEkyVerificationProp,
@@ -20,6 +22,8 @@ export const IdentityVerificationStatus = ({
   cancelPopup,
 }: DefaultEkyVerificationProp) => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { hash: fromSignInHash } = useLocation();
 
   const { hashCode } = useEkycVerificationStore(
     useCallback(
@@ -32,6 +36,9 @@ export const IdentityVerificationStatus = ({
 
   const retriableErrorCodes =
     settings.configs["status.request.retry.error.codes"].split(",");
+
+  // Configurable auto-redirect delay (in seconds)
+  const autoRedirectDelay = settings?.configs["identity-verification.success.redirect-delay"];
 
   useEffect(() => {
     if (window.videoLocalStream) {
@@ -97,16 +104,29 @@ export const IdentityVerificationStatus = ({
     identityVerificationStatus?.response?.status ===
     IdentityVerificationStatusType.COMPLETED
   ) {
-    window.onbeforeunload = null;
-    window.location.href = `${
-      settings.configs["esignet-consent.redirect-url"]
-    }?key=${hashCode?.state || ""}`;
+    const handleRedirect = (e?: React.MouseEvent<HTMLButtonElement>) => {
+      window.onbeforeunload = null;
+      
+      const hasESignetHash = fromSignInHash && fromSignInHash.length > 0;
+      
+      if (hasESignetHash) {
+        window.location.href = `${
+          settings.configs["esignet-consent.redirect-url"]
+        }?key=${hashCode?.state || ""}`;
+      } else {
+        navigate(ROOT_ROUTE);
+      }
+    };
 
     return (
       <IdentityVerificationStatusLayout
         status="success"
         title={t("identity_verification_status.successful.title")}
         description={t("identity_verification_status.successful.description")}
+        btnLabel={t("continue")}
+        onBtnClick={handleRedirect}
+        autoRedirect={true}
+        autoRedirectDelay={autoRedirectDelay}
       />
     );
   }

--- a/signup-ui/src/pages/EkycVerificationPage/IdentityVerificationStatus/IdentityVerificationStatus.tsx
+++ b/signup-ui/src/pages/EkycVerificationPage/IdentityVerificationStatus/IdentityVerificationStatus.tsx
@@ -16,6 +16,7 @@ import {
 import { IdentityVerificationStatusLayout } from "./components/IdentityVerificationStatusLayout";
 import { IdentityVerificationStatusLoader } from "./components/IdentityVerificationStatusLoader";
 import { IdentityVerificationStatusFailed } from "./IdentityVerificationStatusFailed";
+import { getStateData } from "~utils/identityVerificationUtil";
 
 export const IdentityVerificationStatus = ({
   settings,
@@ -106,12 +107,10 @@ export const IdentityVerificationStatus = ({
     const handleRedirect = (e?: React.MouseEvent<HTMLButtonElement>) => {
       window.onbeforeunload = null;
 
-      const hasESignetHash = fromSignInHash && fromSignInHash.length > 0;
-
-      if (hasESignetHash) {
-        handleDismiss({ key: hashCode?.state || "" });
-      } else {
+      if (getStateData(hashCode?.state || "")) {
         navigate(ROOT_ROUTE);
+      } else {
+        handleDismiss({ key: hashCode?.state || "" });
       }
     };
 

--- a/signup-ui/src/pages/EkycVerificationPage/IdentityVerificationStatus/IdentityVerificationStatus.tsx
+++ b/signup-ui/src/pages/EkycVerificationPage/IdentityVerificationStatus/IdentityVerificationStatus.tsx
@@ -38,7 +38,8 @@ export const IdentityVerificationStatus = ({
     settings.configs["status.request.retry.error.codes"].split(",");
 
   // Configurable auto-redirect delay (in seconds)
-  const autoRedirectDelay = settings?.configs["identity-verification.success.redirect-delay"];
+  const autoRedirectDelay =
+    settings?.configs["identity-verification.success.redirect-delay"];
 
   useEffect(() => {
     if (window.videoLocalStream) {
@@ -106,9 +107,9 @@ export const IdentityVerificationStatus = ({
   ) {
     const handleRedirect = (e?: React.MouseEvent<HTMLButtonElement>) => {
       window.onbeforeunload = null;
-      
+
       const hasESignetHash = fromSignInHash && fromSignInHash.length > 0;
-      
+
       if (hasESignetHash) {
         window.location.href = `${
           settings.configs["esignet-consent.redirect-url"]

--- a/signup-ui/src/pages/EkycVerificationPage/IdentityVerificationStatus/IdentityVerificationStatus.tsx
+++ b/signup-ui/src/pages/EkycVerificationPage/IdentityVerificationStatus/IdentityVerificationStatus.tsx
@@ -20,6 +20,7 @@ import { IdentityVerificationStatusFailed } from "./IdentityVerificationStatusFa
 export const IdentityVerificationStatus = ({
   settings,
   cancelPopup,
+  handleDismiss,
 }: DefaultEkyVerificationProp) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -37,9 +38,7 @@ export const IdentityVerificationStatus = ({
   const retriableErrorCodes =
     settings.configs["status.request.retry.error.codes"].split(",");
 
-  // Configurable auto-redirect delay (in seconds)
-  const autoRedirectDelay =
-    settings?.configs["identity-verification.success.redirect-delay"];
+  const autoRedirectDelay = settings.configs["rp.config"].redirect_delay;
 
   useEffect(() => {
     if (window.videoLocalStream) {
@@ -67,6 +66,7 @@ export const IdentityVerificationStatus = ({
       <IdentityVerificationStatusFailed
         settings={settings}
         cancelPopup={cancelPopup}
+        handleDismiss={handleDismiss}
       />
     );
   }
@@ -76,10 +76,10 @@ export const IdentityVerificationStatus = ({
   //    - UPDATE_PENDING
   //    - error codes specified in `status.request.retry.error.codes`
   if (isIdentityVerificationStatusError) {
-    window.onbeforeunload = null;
-    window.location.href = `${
-      settings.configs["esignet-consent.redirect-url"]
-    }?key=${hashCode?.state || ""}&error=ekyc_failed`;
+    handleDismiss({
+      key: hashCode?.state || "",
+      error: "ekyc_failed",
+    });
   }
 
   // scenario:
@@ -91,12 +91,10 @@ export const IdentityVerificationStatus = ({
       identityVerificationStatus.errors[0].errorCode
     )
   ) {
-    window.onbeforeunload = null;
-    window.location.href = `${
-      settings.configs["esignet-consent.redirect-url"]
-    }?key=${hashCode?.state || ""}&error=${
-      identityVerificationStatus.errors[0].errorCode
-    }`;
+    handleDismiss({
+      key: hashCode?.state || "",
+      error: identityVerificationStatus.errors[0].errorCode,
+    });
   }
 
   // scenario:
@@ -111,9 +109,7 @@ export const IdentityVerificationStatus = ({
       const hasESignetHash = fromSignInHash && fromSignInHash.length > 0;
 
       if (hasESignetHash) {
-        window.location.href = `${
-          settings.configs["esignet-consent.redirect-url"]
-        }?key=${hashCode?.state || ""}`;
+        handleDismiss({ key: hashCode?.state || "" });
       } else {
         navigate(ROOT_ROUTE);
       }

--- a/signup-ui/src/pages/EkycVerificationPage/IdentityVerificationStatus/IdentityVerificationStatusFailed.tsx
+++ b/signup-ui/src/pages/EkycVerificationPage/IdentityVerificationStatus/IdentityVerificationStatusFailed.tsx
@@ -10,8 +10,7 @@ import {
 import { IdentityVerificationStatusLayout } from "./components/IdentityVerificationStatusLayout";
 
 export const IdentityVerificationStatusFailed = ({
-  settings,
-  cancelPopup,
+  handleDismiss,
 }: DefaultEkyVerificationProp) => {
   const { t } = useTranslation();
 
@@ -28,10 +27,10 @@ export const IdentityVerificationStatusFailed = ({
     HTMLButtonElement
   > = (e) => {
     e.preventDefault();
-    window.onbeforeunload = null;
-    window.location.href = `${
-      settings.configs["esignet-consent.redirect-url"]
-    }?key=${hashCode?.state || ""}&error=identity_verification_failed`;
+    handleDismiss({
+      key: hashCode?.state || "",
+      error: "identity_verification_failed",
+    });
   };
 
   return (

--- a/signup-ui/src/pages/EkycVerificationPage/IdentityVerificationStatus/components/IdentityVerificationStatusLayout.tsx
+++ b/signup-ui/src/pages/EkycVerificationPage/IdentityVerificationStatus/components/IdentityVerificationStatusLayout.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler, useEffect, useState, useMemo } from "react";
+import { MouseEventHandler, useEffect, useMemo } from "react";
 import { Trans } from "react-i18next";
 import { useTimer } from "react-timer-hook";
 
@@ -49,8 +49,11 @@ export const IdentityVerificationStatusLayout = ({
     };
   }, [autoRedirect, status, onBtnClick, autoRedirectDelay, restart, pause]);
 
-  const countdownDisplay = useMemo(() => convertTime(totalSeconds), [totalSeconds]);
-
+  const countdownDisplay = useMemo(
+    () => convertTime(totalSeconds),
+    [totalSeconds]
+  );
+  
   return (
     <Step>
       <StepContent>
@@ -58,17 +61,20 @@ export const IdentityVerificationStatusLayout = ({
           {status === "success" ? <Icons.success /> : <Icons.failed />}
           <h1 className="status__title">{title}</h1>
           <p className="status__description">{description}</p>
-          <p className="redirect_countdown">
-            <Trans
-              i18nKey="identity_verification_status.successful.countdown"
-              components={{
-                CountDownSpan: <span className="font-bold" />,
-              }}
-              values={{ countDown: countdownDisplay }}
+          {status === "success" && (
+            <p className="redirect_countdown">
+              <Trans
+                i18nKey="identity_verification_status.successful.countdown"
+                components={{
+                  CountDownSpan: <span className="font-bold" />,
+                }}
+                values={{ countDown: countdownDisplay }}
               />
-          </p>
+            </p>
+          )}
         </div>
-        {(status === "failed" || (status === "success" && btnLabel && onBtnClick)) && (
+        {(status === "failed" ||
+          (status === "success" && btnLabel && onBtnClick)) && (
           <Button
             id="success-continue-button"
             className="status__btn"

--- a/signup-ui/src/pages/EkycVerificationPage/IdentityVerificationStatus/components/IdentityVerificationStatusLayout.tsx
+++ b/signup-ui/src/pages/EkycVerificationPage/IdentityVerificationStatus/components/IdentityVerificationStatusLayout.tsx
@@ -1,9 +1,11 @@
-import { MouseEventHandler } from "react";
-import { useTranslation } from "react-i18next";
+import { MouseEventHandler, useEffect, useState, useMemo } from "react";
+import { Trans } from "react-i18next";
+import { useTimer } from "react-timer-hook";
 
 import { Button } from "~components/ui/button";
 import { Icons } from "~components/ui/icons";
 import { Step, StepContent } from "~components/ui/step";
+import { convertTime, getTimeoutTime } from "~utils/timer";
 
 interface IdentityVerificationStatusLayoutProps {
   status: "success" | "failed";
@@ -11,6 +13,8 @@ interface IdentityVerificationStatusLayoutProps {
   description: string;
   btnLabel?: string;
   onBtnClick?: MouseEventHandler<HTMLButtonElement> | undefined;
+  autoRedirect?: boolean;
+  autoRedirectDelay?: number;
 }
 
 export const IdentityVerificationStatusLayout = ({
@@ -19,7 +23,34 @@ export const IdentityVerificationStatusLayout = ({
   description,
   btnLabel,
   onBtnClick,
+  autoRedirect = false,
+  autoRedirectDelay = 10,
 }: IdentityVerificationStatusLayoutProps) => {
+  const { totalSeconds, restart, pause } = useTimer({
+    expiryTimestamp: getTimeoutTime(autoRedirectDelay),
+    onExpire: () => {
+      if (onBtnClick) {
+        onBtnClick({} as React.MouseEvent<HTMLButtonElement>);
+      }
+    },
+    autoStart: false,
+  });
+
+  useEffect(() => {
+    if (autoRedirect && status === "success" && onBtnClick) {
+      restart(getTimeoutTime(autoRedirectDelay));
+    } else {
+      pause();
+    }
+
+    // Cleanup: pause timer on unmount
+    return () => {
+      pause();
+    };
+  }, [autoRedirect, status, onBtnClick, autoRedirectDelay, restart, pause]);
+
+  const countdownDisplay = useMemo(() => convertTime(totalSeconds), [totalSeconds]);
+
   return (
     <Step>
       <StepContent>
@@ -27,8 +58,17 @@ export const IdentityVerificationStatusLayout = ({
           {status === "success" ? <Icons.success /> : <Icons.failed />}
           <h1 className="status__title">{title}</h1>
           <p className="status__description">{description}</p>
+          <p className="redirect_countdown">
+            <Trans
+              i18nKey="identity_verification_status.successful.countdown"
+              components={{
+                CountDownSpan: <span className="font-bold" />,
+              }}
+              values={{ countDown: countdownDisplay }}
+              />
+          </p>
         </div>
-        {status === "failed" && (
+        {(status === "failed" || (status === "success" && btnLabel && onBtnClick)) && (
           <Button
             id="success-continue-button"
             className="status__btn"

--- a/signup-ui/src/pages/EkycVerificationPage/KycProviderList/KycProviderList.tsx
+++ b/signup-ui/src/pages/EkycVerificationPage/KycProviderList/KycProviderList.tsx
@@ -37,6 +37,7 @@ const POLLING_BASE_URL =
 export const KycProviderList = ({
   cancelPopup,
   settings,
+  handleDismiss,
 }: DefaultEkyVerificationProp) => {
   const { i18n, t } = useTranslation("translation", {
     keyPrefix: "kyc_provider",
@@ -88,10 +89,10 @@ export const KycProviderList = ({
   const handleCancel = (e: any) => {
     e.preventDefault();
     if (kycProvidersList === null || kycProvidersList.length === 0) {
-      window.onbeforeunload = null;
-      window.location.href = `${settings?.configs[
-        "esignet-consent.redirect-url"
-      ]}?key=${hashCode?.state || ""}&error=no_ekyc_provider`;
+      handleDismiss({
+        key: hashCode?.state || "",
+        error: "no_ekyc_provider",
+      });
     } else {
       setCancelButton(true);
     }

--- a/signup-ui/src/pages/EkycVerificationPage/LoadingScreen/LoadingScreen.tsx
+++ b/signup-ui/src/pages/EkycVerificationPage/LoadingScreen/LoadingScreen.tsx
@@ -1,5 +1,9 @@
 import { UnsupportedBrowserPerm } from "./components/UnsupportedBrowserPerm";
 
-export const LoadingScreen = () => {
-  return <UnsupportedBrowserPerm />;
+export const LoadingScreen = ({
+  handleDismiss,
+}: {
+  handleDismiss: (args: { key: string; error: string }) => void;
+}) => {
+  return <UnsupportedBrowserPerm handleDismiss={handleDismiss} />;
 };

--- a/signup-ui/src/pages/EkycVerificationPage/LoadingScreen/components/UnsupportedBrowserPerm.tsx
+++ b/signup-ui/src/pages/EkycVerificationPage/LoadingScreen/components/UnsupportedBrowserPerm.tsx
@@ -9,16 +9,18 @@ import {
   StepHeader,
   StepTitle,
 } from "~components/ui/step";
-import { useSettings } from "~pages/shared/queries";
 
 import {
   hashCodeSelector,
   useEkycVerificationStore,
 } from "../../useEkycVerificationStore";
 
-export const UnsupportedBrowserPerm = () => {
+export const UnsupportedBrowserPerm = ({
+  handleDismiss,
+}: {
+  handleDismiss: (args: { key: string; error: string }) => void;
+}) => {
   const { t } = useTranslation();
-  const { data: settings } = useSettings();
 
   const { hashCode } = useEkycVerificationStore(
     useCallback(
@@ -30,10 +32,10 @@ export const UnsupportedBrowserPerm = () => {
   );
 
   const handleOkay = () => {
-    window.onbeforeunload = null;
-    window.location.href = `${settings?.response?.configs[
-      "esignet-consent.redirect-url"
-    ]}?key=${hashCode?.state || ""}&error=incompatible_browser`;
+    handleDismiss({
+      key: hashCode?.state || "",
+      error: "incompatible_browser",
+    });
   };
 
   return (

--- a/signup-ui/src/pages/EkycVerificationPage/SlotChecking/SlotChecking.tsx
+++ b/signup-ui/src/pages/EkycVerificationPage/SlotChecking/SlotChecking.tsx
@@ -19,7 +19,10 @@ import {
 import { SlotCheckingLoading } from "./components/SlotCheckingLoading";
 import { SlotUnavailableAlert } from "./components/SlotUnavailableAlert";
 
-export const SlotChecking = ({ settings }: DefaultEkyVerificationProp) => {
+export const SlotChecking = ({
+  settings,
+  handleDismiss,
+}: DefaultEkyVerificationProp) => {
   const { slotAvailabilityMutation } = useSlotAvailability({
     retryAttempt: settings.configs["slot.request.limit"],
     retryDelay: settings.configs["slot.request.delay"],
@@ -75,10 +78,8 @@ export const SlotChecking = ({ settings }: DefaultEkyVerificationProp) => {
 
   if (slotAvailabilityMutation.isPending) {
     return <SlotCheckingLoading />;
-  } else if (
-    criticalError?.errorCode === "slot_not_available"
-  ) {
-    return <SlotUnavailableAlert />;
+  } else if (criticalError?.errorCode === "slot_not_available") {
+    return <SlotUnavailableAlert handleDismiss={handleDismiss} />;
   }
   return <></>;
 };

--- a/signup-ui/src/pages/EkycVerificationPage/SlotChecking/components/SlotUnavailableAlert.tsx
+++ b/signup-ui/src/pages/EkycVerificationPage/SlotChecking/components/SlotUnavailableAlert.tsx
@@ -4,16 +4,18 @@ import { useTranslation } from "react-i18next";
 import { Button } from "~components/ui/button";
 import { Icons } from "~components/ui/icons";
 import { Step, StepContent } from "~components/ui/step";
-import { useSettings } from "~pages/shared/queries";
 
 import {
   hashCodeSelector,
   useEkycVerificationStore,
 } from "../../useEkycVerificationStore";
 
-export const SlotUnavailableAlert = () => {
+export const SlotUnavailableAlert = ({
+  handleDismiss,
+}: {
+  handleDismiss: (args: { key: string; error: string }) => void;
+}) => {
   const { t } = useTranslation();
-  const { data: settings } = useSettings();
 
   const { hashCode } = useEkycVerificationStore(
     useCallback(
@@ -26,10 +28,10 @@ export const SlotUnavailableAlert = () => {
 
   const handleContinue = (e: any) => {
     e.preventDefault();
-    window.onbeforeunload = null;
-    window.location.href = `${settings?.response?.configs[
-      "esignet-consent.redirect-url"
-    ]}?key=${hashCode?.state || ""}&error=ekyc_failed`;
+    handleDismiss({
+      key: hashCode?.state || "",
+      error: "ekyc_failed",
+    });
   };
 
   return (

--- a/signup-ui/src/pages/EkycVerificationPage/VerificationScreen/VerificationScreen.tsx
+++ b/signup-ui/src/pages/EkycVerificationPage/VerificationScreen/VerificationScreen.tsx
@@ -38,6 +38,7 @@ import { EkycStatusAlert } from "./components/EkycStatusAlert";
 export const VerificationScreen = ({
   cancelPopup,
   settings,
+  handleDismiss,
 }: DefaultEkyVerificationProp) => {
   const { t, i18n } = useTranslation("translation", {
     keyPrefix: "verification_screen",
@@ -115,12 +116,10 @@ export const VerificationScreen = ({
             className="my-4 h-16 w-full"
             type="button"
             onClick={() => {
-              window.onbeforeunload = null;
-              window.location.replace(
-                `${settings?.configs["esignet-consent.redirect-url"]}?key=${
-                  hashCode?.state || ""
-                }&error=web_socket_fail`
-              );
+              handleDismiss({
+                key: hashCode?.state || "",
+                error: "web_socket_fail",
+              });
             }}
           >
             {t("web_socket_error.button")}

--- a/signup-ui/src/pages/EkycVerificationPage/useEkycVerificationStore.tsx
+++ b/signup-ui/src/pages/EkycVerificationPage/useEkycVerificationStore.tsx
@@ -20,6 +20,19 @@ export enum EkycVerificationStep {
   IdentityVerificationStatus,
 }
 
+const initialState = {
+  step: EkycVerificationStep.VerificationSteps,
+  criticalError: null as Error | null,
+  kycProvider: null as KycProvider | null,
+  kycProviderDetail: null as KycProviderDetail | null,
+  kycProvidersList: null as KycProvider[] | null,
+  hashCode: null as SignupHashCode | null,
+  isNoBackground: false as boolean,
+  errorBannerMessage: null as string | null,
+  slotId: null as string | null,
+  providerListStatus: false as boolean,
+}
+
 export type EkycVerificationStore = {
   step: EkycVerificationStep;
   setStep: (step: EkycVerificationStep) => void;
@@ -43,19 +56,6 @@ export type EkycVerificationStore = {
   setProviderListStatus: (providerListStatus: boolean) => void;
   reset: () => void;
 };
-
-const initialState = {
-  step: EkycVerificationStep.VerificationSteps,
-  criticalError: null,
-  kycProvider: null,
-  kycProviderDetail: null,
-  kycProvidersList: null,
-  hashCode: null,
-  isNoBackground: false,
-  errorBannerMessage: null,
-  slotId: null,
-  providerListStatus: false,
-}
 
 export const useEkycVerificationStore = create<EkycVerificationStore>()(
   devtools((set, get) => ({

--- a/signup-ui/src/pages/EkycVerificationPage/useEkycVerificationStore.tsx
+++ b/signup-ui/src/pages/EkycVerificationPage/useEkycVerificationStore.tsx
@@ -41,7 +41,21 @@ export type EkycVerificationStore = {
   setSlotId: (slotId: string | null) => void;
   providerListStatus: boolean;
   setProviderListStatus: (providerListStatus: boolean) => void;
+  reset: () => void;
 };
+
+const initialState = {
+  step: EkycVerificationStep.VerificationSteps,
+  criticalError: null,
+  kycProvider: null,
+  kycProviderDetail: null,
+  kycProvidersList: null,
+  hashCode: null,
+  isNoBackground: false,
+  errorBannerMessage: null,
+  slotId: null,
+  providerListStatus: false,
+}
 
 export const useEkycVerificationStore = create<EkycVerificationStore>()(
   devtools((set, get) => ({
@@ -105,6 +119,7 @@ export const useEkycVerificationStore = create<EkycVerificationStore>()(
       if (isEqual(current.providerListStatus, providerListStatus)) return;
       set((state) => ({ providerListStatus }));
     },
+    reset: () => set(() => initialState)
   }))
 );
 

--- a/signup-ui/src/pages/LandingPage/LandingPage.tsx
+++ b/signup-ui/src/pages/LandingPage/LandingPage.tsx
@@ -3,10 +3,12 @@ import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { ReactComponent as SomethingWentWrongSvg } from "~assets/svg/something-went-wrong.svg";
-import { RESET_PASSWORD, SIGNUP_ROUTE } from "~constants/routes";
+import { EKYC_VERIFICATION, RESET_PASSWORD, SIGNUP_ROUTE } from "~constants/routes";
 import { Button } from "~components/ui/button";
 import { useSignUpStore } from "~pages/SignUpPage/useSignUpStore";
 import { useResetPasswordStore } from "~pages/ResetPasswordPage/useResetPasswordStore";
+import { generateState } from "~utils/link";
+import { useEkycVerificationStore } from "~pages/EkycVerificationPage/useEkycVerificationStore";
 
 export const LandingPage = () => {
   const { t } = useTranslation();
@@ -14,6 +16,7 @@ export const LandingPage = () => {
   const { hash: fromSignInHash } = useLocation();
   const resetSignupStore = useSignUpStore.getState().reset;
   const resetForgotPasswordStore = useResetPasswordStore.getState().reset;
+  const resetEkycVerificationStore = useEkycVerificationStore.getState().reset;
 
   const handleResetPassword = (e: any) => {
     e.preventDefault();
@@ -25,6 +28,13 @@ export const LandingPage = () => {
     e.preventDefault();
     resetSignupStore();
     navigate(`${SIGNUP_ROUTE}${fromSignInHash}`);
+  };
+
+  const handleVerifyIdentity = (e: any) => {
+    e.preventDefault();
+    resetEkycVerificationStore();
+    const state = generateState();
+    navigate(`${EKYC_VERIFICATION}${fromSignInHash}?state=${state}`);
   };
 
   return (
@@ -40,9 +50,9 @@ export const LandingPage = () => {
             {t("landing_page_description")}
           </p>
         </div>
-        <div className="flex w-full flex-row items-center justify-center gap-x-2 sm:flex-col">
+        <div className="flex w-full flex-row items-center justify-center gap-x-2 md:flex-col">
           <Button
-            className="h-[52px] w-[250px] border-[2px] border-primary bg-white text-primary hover:text-primary/80 sm:mb-3 sm:w-full"
+            className="h-[52px] w-[250px] border-[2px] border-primary bg-white text-primary hover:text-primary/80 md:mb-3 md:w-full"
             id="reset-password-button"
             name="reset-password-button"
             variant="outline"
@@ -51,12 +61,21 @@ export const LandingPage = () => {
             {t("reset_password")}
           </Button>
           <Button
-            className="h-[52px] w-[250px] sm:w-full"
+            className="h-[52px] w-[250px] md:w-full"
             id="register-button"
             name="register-button"
             onClick={handleRegister}
           >
             {t("register")}
+          </Button>
+          <Button
+            className="h-[52px] w-[250px] border-[2px] border-primary bg-white text-primary hover:text-primary/80 md:mt-3 md:w-full"
+            id="verify-identity-button"
+            name="verify-identity-button"
+            variant="outline"
+            onClick={handleVerifyIdentity}
+          >
+            {t("verify_identity")}
           </Button>
         </div>
       </div>

--- a/signup-ui/src/pages/LandingPage/LandingPage.tsx
+++ b/signup-ui/src/pages/LandingPage/LandingPage.tsx
@@ -12,11 +12,15 @@ import { Button } from "~components/ui/button";
 import { generateState } from "~utils/identityVerificationUtil";
 import { useEkycVerificationStore } from "~pages/EkycVerificationPage/useEkycVerificationStore";
 import { useResetPasswordStore } from "~pages/ResetPasswordPage/useResetPasswordStore";
+import { useSettings } from "~pages/shared/queries";
 import { useSignUpStore } from "~pages/SignUpPage/useSignUpStore";
 
 export const LandingPage = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const navigate = useNavigate();
+
+  const { data: settings } = useSettings();
+
   const { hash: fromSignInHash } = useLocation();
   const resetSignupStore = useSignUpStore.getState().reset;
   const resetForgotPasswordStore = useResetPasswordStore.getState().reset;
@@ -37,7 +41,14 @@ export const LandingPage = () => {
   const handleVerifyIdentity = (e: any) => {
     e.preventDefault();
     resetEkycVerificationStore();
-    const state = generateState();
+    const rpConfig = settings?.response?.configs["rp.config"];
+    const state = generateState({
+      redirectUrl: rpConfig?.redirect_uri_verification,
+      expiryTime: rpConfig?.expiry_time,
+      scope: rpConfig?.scope,
+      acrValues: rpConfig?.acr_values,
+      uiLocales: i18n.language,
+    });
     navigate(`${EKYC_VERIFICATION}${fromSignInHash}?state=${state}`);
   };
 

--- a/signup-ui/src/pages/LandingPage/LandingPage.tsx
+++ b/signup-ui/src/pages/LandingPage/LandingPage.tsx
@@ -89,6 +89,7 @@ export const LandingPage = () => {
             name="verify-identity-button"
             variant="outline"
             onClick={handleVerifyIdentity}
+            disabled={settings !== undefined ? false : true}
           >
             {t("verify_identity")}
           </Button>

--- a/signup-ui/src/pages/LandingPage/LandingPage.tsx
+++ b/signup-ui/src/pages/LandingPage/LandingPage.tsx
@@ -3,12 +3,16 @@ import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { ReactComponent as SomethingWentWrongSvg } from "~assets/svg/something-went-wrong.svg";
-import { EKYC_VERIFICATION, RESET_PASSWORD, SIGNUP_ROUTE } from "~constants/routes";
+import {
+  EKYC_VERIFICATION,
+  RESET_PASSWORD,
+  SIGNUP_ROUTE,
+} from "~constants/routes";
 import { Button } from "~components/ui/button";
-import { useSignUpStore } from "~pages/SignUpPage/useSignUpStore";
-import { useResetPasswordStore } from "~pages/ResetPasswordPage/useResetPasswordStore";
-import { generateState } from "~utils/link";
+import { generateState } from "~utils/identityVerificationUtil";
 import { useEkycVerificationStore } from "~pages/EkycVerificationPage/useEkycVerificationStore";
+import { useResetPasswordStore } from "~pages/ResetPasswordPage/useResetPasswordStore";
+import { useSignUpStore } from "~pages/SignUpPage/useSignUpStore";
 
 export const LandingPage = () => {
   const { t } = useTranslation();

--- a/signup-ui/src/pages/ResetPasswordPage/ResetPasswordConfirmation/components/ResetPasswordConfirmationLayout.tsx
+++ b/signup-ui/src/pages/ResetPasswordPage/ResetPasswordConfirmation/components/ResetPasswordConfirmationLayout.tsx
@@ -26,7 +26,7 @@ export const ResetPasswordConfirmationLayout = ({
   const handleAction = (e: any) => {
     e.preventDefault();
     window.location.href = getSignInRedirectURLV2(
-      settings?.response.configs["signin.redirect-url"],
+      settings?.response.configs["rp.config"].redirect_uri_signin,
       fromSignInHash,
       search,
       RESET_PASSWORD

--- a/signup-ui/src/pages/ResetPasswordPage/ResetPasswordPopover.tsx
+++ b/signup-ui/src/pages/ResetPasswordPage/ResetPasswordPopover.tsx
@@ -49,7 +49,7 @@ export const ResetPasswordPopover = () => {
       }
     } else {
       window.location.href = getSignInRedirectURLV2(
-        settings?.response.configs["signin.redirect-url"],
+        settings?.response.configs["rp.config"].redirect_uri_signin,
         fromSignInHash,
         search,
         RESET_PASSWORD

--- a/signup-ui/src/pages/ResetPasswordPage/UserInfo/UserInfo.tsx
+++ b/signup-ui/src/pages/ResetPasswordPage/UserInfo/UserInfo.tsx
@@ -4,7 +4,6 @@ import {
   KeyboardEvent,
   MouseEvent,
   useCallback,
-  useMemo,
   useRef,
   useState,
 } from "react";
@@ -211,7 +210,7 @@ export const UserInfo = ({ settings, methods }: UserInfoProps) => {
             {!!fromSignInHash && (
               <a
                 href={getSignInRedirectURLV2(
-                  settings?.response.configs["rp.config"].redirect_uri_signin,
+                  settings?.response?.configs["rp.config"]?.redirect_uri_signin,
                   fromSignInHash,
                   search,
                   RESET_PASSWORD

--- a/signup-ui/src/pages/ResetPasswordPage/UserInfo/UserInfo.tsx
+++ b/signup-ui/src/pages/ResetPasswordPage/UserInfo/UserInfo.tsx
@@ -211,7 +211,7 @@ export const UserInfo = ({ settings, methods }: UserInfoProps) => {
             {!!fromSignInHash && (
               <a
                 href={getSignInRedirectURLV2(
-                  settings?.response.configs["signin.redirect-url"],
+                  settings?.response.configs["rp.config"].redirect_uri_signin,
                   fromSignInHash,
                   search,
                   RESET_PASSWORD

--- a/signup-ui/src/pages/SignUpPage/AccountRegistrationStatus/components/AccountRegistrationStatusLayout.tsx
+++ b/signup-ui/src/pages/SignUpPage/AccountRegistrationStatus/components/AccountRegistrationStatusLayout.tsx
@@ -80,20 +80,22 @@ export const AccountRegistrationStatusLayout = ({
         </div>
         <div className="flex w-full flex-row items-center justify-center gap-x-2 md:flex-col">
           <Button
-          id="success-continue-button"
-          className="my-4 h-16 md:mb-3 w-full"
-          onClick={handleAction}
-        >
-          {fromSignInHash ? t("login") : t("okay")}
-        </Button>
-        <Button
-          id="verify-identity-button"
-          className="my-4 h-16 border-primary bg-white text-primary hover:text-primary/80 md:mt-3 w-full"
-          variant="outline"
-          onClick={handleVerifyIdentity}
-        >
-          {t("proceed_to_verification")}
-        </Button>
+            id="success-continue-button"
+            className="my-4 h-16 md:mb-3 w-full"
+            onClick={handleAction}
+          >
+            {fromSignInHash ? t("login") : t("okay")}
+          </Button>
+          {status === "success" && (
+            <Button
+              id="verify-identity-button"
+              className="my-4 h-16 border-primary bg-white text-primary hover:text-primary/80 md:mt-3 w-full"
+              variant="outline"
+              onClick={handleVerifyIdentity}
+            >
+              {t("proceed_to_verification")}
+            </Button>
+          )}
         </div>
       </StepContent>
     </Step>

--- a/signup-ui/src/pages/SignUpPage/AccountRegistrationStatus/components/AccountRegistrationStatusLayout.tsx
+++ b/signup-ui/src/pages/SignUpPage/AccountRegistrationStatus/components/AccountRegistrationStatusLayout.tsx
@@ -1,13 +1,15 @@
 import { useTranslation } from "react-i18next";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import { ReactComponent as FailedIconSvg } from "~assets/svg/failed-icon.svg";
 import { ReactComponent as SuccessIconSvg } from "~assets/svg/success-icon.svg";
 import { ReactComponent as WarningIconSvg } from "~assets/svg/warning-icon.svg";
 import { Button } from "~components/ui/button";
 import { Step, StepContent } from "~components/ui/step";
-import { getSignInRedirectURLV2 } from "~utils/link";
+import { EKYC_VERIFICATION } from "~constants/routes";
+import { getSignInRedirectURLV2, generateState } from "~utils/link";
 import { useSettings } from "~pages/shared/queries";
+import { useEkycVerificationStore } from "~pages/EkycVerificationPage/useEkycVerificationStore";
 
 interface AccountRegistrationStatusLayoutProps {
   status: "success" | "warning" | "failed";
@@ -21,6 +23,8 @@ export const AccountRegistrationStatusLayout = ({
   const { t } = useTranslation();
   const { data: settings } = useSettings();
   const { hash: fromSignInHash, search } = useLocation();
+  const navigate = useNavigate();
+  const resetEkycVerificationStore = useEkycVerificationStore.getState().reset;
 
   const handleAction = (e: any) => {
     e.preventDefault();
@@ -30,6 +34,13 @@ export const AccountRegistrationStatusLayout = ({
       search,
       "/signup"
     );
+  };
+
+  const handleVerifyIdentity = (e: any) => {
+    e.preventDefault();
+    resetEkycVerificationStore();
+    const state = generateState();
+    navigate(`${EKYC_VERIFICATION}${fromSignInHash}?state=${state}`);
   };
 
   return (
@@ -59,13 +70,23 @@ export const AccountRegistrationStatusLayout = ({
           </div>
           <p className="text-center text-gray-500">{message}</p>
         </div>
-        <Button
+        <div className="flex w-full flex-row items-center justify-center gap-x-2 md:flex-col">
+          <Button
           id="success-continue-button"
-          className="my-4 h-16 w-full"
+          className="my-4 h-16 md:mb-3 w-full"
           onClick={handleAction}
         >
           {fromSignInHash ? t("login") : t("okay")}
         </Button>
+        <Button
+          id="verify-identity-button"
+          className="my-4 h-16 border-primary bg-white text-primary hover:text-primary/80 md:mt-3 w-full"
+          variant="outline"
+          onClick={handleVerifyIdentity}
+        >
+          {t("proceed_to_verification")}
+        </Button>
+        </div>
       </StepContent>
     </Step>
   );

--- a/signup-ui/src/pages/SignUpPage/AccountRegistrationStatus/components/AccountRegistrationStatusLayout.tsx
+++ b/signup-ui/src/pages/SignUpPage/AccountRegistrationStatus/components/AccountRegistrationStatusLayout.tsx
@@ -7,9 +7,10 @@ import { ReactComponent as WarningIconSvg } from "~assets/svg/warning-icon.svg";
 import { Button } from "~components/ui/button";
 import { Step, StepContent } from "~components/ui/step";
 import { EKYC_VERIFICATION } from "~constants/routes";
-import { getSignInRedirectURLV2, generateState } from "~utils/link";
+import { getSignInRedirectURLV2 } from "~utils/link";
 import { useSettings } from "~pages/shared/queries";
 import { useEkycVerificationStore } from "~pages/EkycVerificationPage/useEkycVerificationStore";
+import { generateState } from "~utils/identityVerificationUtil";
 
 interface AccountRegistrationStatusLayoutProps {
   status: "success" | "warning" | "failed";

--- a/signup-ui/src/pages/SignUpPage/AccountRegistrationStatus/components/AccountRegistrationStatusLayout.tsx
+++ b/signup-ui/src/pages/SignUpPage/AccountRegistrationStatus/components/AccountRegistrationStatusLayout.tsx
@@ -21,16 +21,17 @@ export const AccountRegistrationStatusLayout = ({
   status,
   message,
 }: AccountRegistrationStatusLayoutProps) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { data: settings } = useSettings();
   const { hash: fromSignInHash, search } = useLocation();
   const navigate = useNavigate();
   const resetEkycVerificationStore = useEkycVerificationStore.getState().reset;
+  const rpConfig = settings?.response?.configs["rp.config"];
 
   const handleAction = (e: any) => {
     e.preventDefault();
     window.location.href = getSignInRedirectURLV2(
-      settings?.response.configs["signin.redirect-url"],
+      rpConfig?.redirect_uri_signin,
       fromSignInHash,
       search,
       "/signup"
@@ -40,7 +41,13 @@ export const AccountRegistrationStatusLayout = ({
   const handleVerifyIdentity = (e: any) => {
     e.preventDefault();
     resetEkycVerificationStore();
-    const state = generateState();
+    const state = generateState({
+      redirectUrl: rpConfig?.redirect_uri_verification,
+      expiryTime: rpConfig?.expiry_time,
+      scope: rpConfig?.scope,
+      acrValues: rpConfig?.acr_values,
+      uiLocales: i18n.language,
+    });
     navigate(`${EKYC_VERIFICATION}${fromSignInHash}?state=${state}`);
   };
 

--- a/signup-ui/src/pages/SignUpPage/AccountSetup/AccountSetup.tsx
+++ b/signup-ui/src/pages/SignUpPage/AccountSetup/AccountSetup.tsx
@@ -134,6 +134,7 @@ export const AccountSetup = ({ settings, methods }: AccountSetupProps) => {
         consent: data.consent ? "AGREE" : "DISAGREE",
         userInfo: {
           ...data,
+          'IDSchemaVersion': '0.1',
         },
         locale: i18n.language,
       },

--- a/signup-ui/src/pages/SignUpPage/AccountSetup/AccountSetup.tsx
+++ b/signup-ui/src/pages/SignUpPage/AccountSetup/AccountSetup.tsx
@@ -134,7 +134,6 @@ export const AccountSetup = ({ settings, methods }: AccountSetupProps) => {
         consent: data.consent ? "AGREE" : "DISAGREE",
         userInfo: {
           ...data,
-          'IDSchemaVersion': '0.1',
         },
         locale: i18n.language,
       },

--- a/signup-ui/src/pages/SignUpPage/AccountSetup/components/UploadFileErrorModal.tsx
+++ b/signup-ui/src/pages/SignUpPage/AccountSetup/components/UploadFileErrorModal.tsx
@@ -17,7 +17,7 @@ export const UploadFileErrorModal = () => {
     e.preventDefault();
     window.onbeforeunload = null;
     window.location.href = getSignInRedirectURLV2(
-      settings?.response.configs["signin.redirect-url"],
+      settings?.response.configs["rp.config"].redirect_uri_signin,
       fromSignInHash,
       search,
       "/signup"

--- a/signup-ui/src/pages/SignUpPage/Phone/Phone.tsx
+++ b/signup-ui/src/pages/SignUpPage/Phone/Phone.tsx
@@ -172,7 +172,7 @@ export const Phone = ({ settings, methods }: PhoneProps) => {
           {!!fromSignInHash && (
             <a
               href={getSignInRedirectURLV2(
-                settings?.response.configs["signin.redirect-url"],
+                settings?.response.configs["rp.config"].redirect_uri_signin,
                 fromSignInHash,
                 search,
                 "/signup"

--- a/signup-ui/src/pages/SignUpPage/PhoneStatus/PhoneStatus.tsx
+++ b/signup-ui/src/pages/SignUpPage/PhoneStatus/PhoneStatus.tsx
@@ -53,7 +53,7 @@ export const PhoneStatus = ({ methods }: PhoneStatusProps) => {
   const handleChallengeVerificationErrorRedirect = (e: any) => {
     e.preventDefault();
     window.location.href = getSignInRedirectURLV2(
-      settings?.response.configs["signin.redirect-url"],
+      settings?.response.configs["rp.config"].redirect_uri_signin,
       fromSignInHash,
       search,
       "/signup"

--- a/signup-ui/src/pages/SignUpPage/SignUpPopover.tsx
+++ b/signup-ui/src/pages/SignUpPage/SignUpPopover.tsx
@@ -35,7 +35,7 @@ export const SignUpPopover = () => {
   const handleAction = (e: any) => {
     e.preventDefault();
     window.location.href = getSignInRedirectURLV2(
-      settings?.response.configs["signin.redirect-url"],
+      settings?.response.configs["rp.config"].redirect_uri_signin,
       fromSignInHash,
       search,
       "/signup"

--- a/signup-ui/src/resources.d.ts
+++ b/signup-ui/src/resources.d.ts
@@ -2,6 +2,8 @@ interface Resources {
   translation: {
     logo_alt: string;
     register: string;
+    verify_identity: string;
+    proceed_to_verification: string;
     landing_page_title: string;
     landing_page_description: string;
     enter_your_number: string;

--- a/signup-ui/src/resources.d.ts
+++ b/signup-ui/src/resources.d.ts
@@ -120,6 +120,7 @@ interface Resources {
       successful: {
         title: string;
         description: string;
+        countdown: string;
       };
       failed: {
         title: string;

--- a/signup-ui/src/typings/types.ts
+++ b/signup-ui/src/typings/types.ts
@@ -127,6 +127,20 @@ export interface BaseRequestDto {
   request: { [key: string]: any };
 }
 
+export interface RpConfig {
+  client_id: string;
+  redirect_uri_verification: string;
+  redirect_uri_signin: string;
+  redirect_uri_consent: string;
+  authorization_endpoint: string;
+  response_type: string;
+  scope: string;
+  claims: string;
+  acr_values: string;
+  expiry_time: number;
+  redirect_delay: number;
+}
+
 export interface SettingsConfig {
   "identifier.name": string;
   "identifier.pattern": string;
@@ -169,6 +183,7 @@ export interface SettingsConfig {
   "broswer.minimum-version": { [key: string]: string };
   "esignet-consent.redirect-url": string;
   "identity-verification.success.redirect-delay": number;
+  "rp.config": RpConfig;
 }
 
 export interface Settings {
@@ -336,6 +351,7 @@ export interface IdentityVerificationState {
 export interface DefaultEkyVerificationProp {
   settings: Settings;
   cancelPopup: (cancelProp: CancelPopup) => any;
+  handleDismiss: (params: any) => void;
 }
 
 export interface CancelPopup {

--- a/signup-ui/src/typings/types.ts
+++ b/signup-ui/src/typings/types.ts
@@ -168,6 +168,7 @@ export interface SettingsConfig {
   "offline.polling.url": string;
   "broswer.minimum-version": { [key: string]: string };
   "esignet-consent.redirect-url": string;
+  "identity-verification.success.redirect-delay": number;
 }
 
 export interface Settings {

--- a/signup-ui/src/utils/identityVerificationUtil.ts
+++ b/signup-ui/src/utils/identityVerificationUtil.ts
@@ -22,6 +22,34 @@ const clearLocalStorageKey = (keyPrefix: string) => {
 };
 
 /**
+ * Removes a specific token from a %20-separated (URL-encoded) list.
+ * Preserves colons (:) and other safe characters when re-encoding.
+ *
+ * @param {string} acr - The input string (URL-encoded, tokens separated by %20).
+ * @param {string} tokenToRemove - The exact token to remove (plain text, not encoded).
+ * @returns {string} - The URL-encoded string with the token removed.
+ */
+const removeEncodedToken = (acr: string, tokenToRemove: string): string => {
+  if (acr === "") {
+    return "mosip:idp:acr:generated-code%20mosip:idp:acr:password%20mosip:idp:acr:linked-wallet%20mosip:idp:acr:knowledge";
+  }
+  // 1) Decode to operate on plain text
+  const decoded = decodeURIComponent(acr); // %20 -> ' '
+
+  // 2) Split on whitespace (handles multiple spaces just in case)
+  const tokens = decoded.trim().split(/\s+/);
+
+  // 3) Filter out the target token (exact match)
+  const filtered = tokens.filter((t) => t !== tokenToRemove);
+
+  // 4) Re-encode; keep ':' readable, optionally also keep '-' safe
+  // encodeURIComponent encodes ':', so we bring it back for readability.
+  return encodeURIComponent(filtered.join(" "))
+    .replace(/%3A/g, ":")
+    .replace(/%2D/g, "-"); // optional: keep dashes readable
+};
+
+/**
  * Generates a unique state string for identity verification and stores related data in localStorage.
  * The state includes a timestamp, redirect URL, and expiry time.
  * @param stateObj - An object containing optional redirectUrl and expiryTime (in seconds).
@@ -29,6 +57,7 @@ const clearLocalStorageKey = (keyPrefix: string) => {
  */
 export const generateState = (stateObj: any = {}): string => {
   const currentDate = new Date();
+
   const stateData = {
     timestamp: currentDate.getTime(),
     redirectUrl:
@@ -37,9 +66,10 @@ export const generateState = (stateObj: any = {}): string => {
     claims: stateObj.claims || "",
     expiry: currentDate.getTime() + (stateObj.expiryTime || 600) * 1000, // default 10 minutes
     uiLocales: stateObj.uiLocales || (window as any)._env_.DEFAULT_LANG,
-    acrValues:
-      stateObj.acrValues ||
-      "mosip:idp:acr:generated-code%20mosip:idp:acr:password%20mosip:idp:acr:linked-wallet%20mosip:idp:acr:knowledge",
+    acrValues: removeEncodedToken(
+      stateObj.acrValues || "",
+      "mosip:idp:acr:id-token"
+    ),
   };
 
   const stateKey = randomKey("identity-verification");

--- a/signup-ui/src/utils/identityVerificationUtil.ts
+++ b/signup-ui/src/utils/identityVerificationUtil.ts
@@ -5,8 +5,21 @@
  * @returns {string} - A base64 encoded string representing the unique state key.
  */
 const randomKey = (prefix: string): string => {
-  const timestamp = new Date().getTime();
-  return `${prefix}-${timestamp}`;
+  const randomUid = crypto.randomUUID().replace(/-/g, "");
+  return `${prefix}-${randomUid}`;
+};
+
+/**
+ * Encodes or decodes a string using Base64.
+ * @param str String to be encoded or decoded
+ * @param encode Whether to encode (true) or decode (false)
+ * @returns Encoded or decoded string
+ */
+const encoderDecoder = (str: string, encode: boolean = false): string => {
+  if (encode) {
+    return Buffer.from(str, "utf8").toString("base64");
+  }
+  return Buffer.from(str, "base64").toString("utf8");
 };
 
 /**
@@ -75,9 +88,9 @@ export const generateState = (stateObj: any = {}): string => {
   const stateKey = randomKey("identity-verification");
 
   clearLocalStorageKey("identity-verification");
-  localStorage.setItem(stateKey, btoa(JSON.stringify(stateData)));
+  localStorage.setItem(stateKey, encoderDecoder(JSON.stringify(stateData), true));
 
-  return btoa(stateKey);
+  return encoderDecoder(stateKey, true);
 };
 
 /**
@@ -87,10 +100,10 @@ export const generateState = (stateObj: any = {}): string => {
  */
 export const getStateData = (stateKeyEncoded: string): any | null => {
   try {
-    const stateKey = atob(stateKeyEncoded);
+    const stateKey = encoderDecoder(stateKeyEncoded);
     const stateDataEncoded = localStorage.getItem(stateKey);
     if (stateDataEncoded) {
-      const stateData = JSON.parse(atob(stateDataEncoded));
+      const stateData = JSON.parse(encoderDecoder(stateDataEncoded));
       const currentTime = new Date().getTime();
       if (stateData.expiry && currentTime > stateData.expiry) {
         // State has expired

--- a/signup-ui/src/utils/identityVerificationUtil.ts
+++ b/signup-ui/src/utils/identityVerificationUtil.ts
@@ -1,0 +1,77 @@
+/**
+ * Generates a unique state string for identity verification and stores related data in localStorage.
+ * The state includes a timestamp, redirect URL, and expiry time.
+ * @param {Object} stateObj - An object containing optional redirectUrl and expiryTime (in seconds).
+ * @returns {string} - A base64 encoded string representing the unique state key.
+ */
+const randomKey = (prefix: string): string => {
+  const timestamp = new Date().getTime();
+  return `${prefix}-${timestamp}`;
+};
+
+/**
+ * Clears all localStorage entries that start with the given key prefix.
+ * @param keyPrefix - The prefix of the keys to be cleared from localStorage.
+ */
+const clearLocalStorageKey = (keyPrefix: string) => {
+  for (let key in localStorage) {
+    if (key.startsWith(keyPrefix)) {
+      localStorage.removeItem(key);
+    }
+  }
+};
+
+/**
+ * Generates a unique state string for identity verification and stores related data in localStorage.
+ * The state includes a timestamp, redirect URL, and expiry time.
+ * @param stateObj - An object containing optional redirectUrl and expiryTime (in seconds).
+ * @returns {string} - A base64 encoded string representing the unique state key.
+ */
+export const generateState = (stateObj: any = {}): string => {
+  const currentDate = new Date();
+  const stateData = {
+    timestamp: currentDate.getTime(),
+    redirectUrl:
+      stateObj.redirectUrl || window.location.origin + "/identity-verification",
+    scope: stateObj.scope || "openid",
+    claims: stateObj.claims || "",
+    expiry: currentDate.getTime() + (stateObj.expiryTime || 600) * 1000, // default 10 minutes
+    uiLocales: stateObj.uiLocales || (window as any)._env_.DEFAULT_LANG,
+    acrValues:
+      stateObj.acrValues ||
+      "mosip:idp:acr:generated-code%20mosip:idp:acr:password%20mosip:idp:acr:linked-wallet%20mosip:idp:acr:knowledge",
+  };
+
+  const stateKey = randomKey("identity-verification");
+
+  clearLocalStorageKey("identity-verification");
+  localStorage.setItem(stateKey, btoa(JSON.stringify(stateData)));
+
+  return btoa(stateKey);
+};
+
+/**
+ * Retrieves and decodes the state data from localStorage using the provided encoded state key.
+ * @param stateKeyEncoded - A base64 encoded string representing the unique state key.
+ * @returns The decoded state data object or null if not found or expired.
+ */
+export const getStateData = (stateKeyEncoded: string): any | null => {
+  try {
+    const stateKey = atob(stateKeyEncoded);
+    const stateDataEncoded = localStorage.getItem(stateKey);
+    if (stateDataEncoded) {
+      const stateData = JSON.parse(atob(stateDataEncoded));
+      const currentTime = new Date().getTime();
+      if (stateData.expiry && currentTime > stateData.expiry) {
+        // State has expired
+        localStorage.removeItem(stateKey);
+        return null;
+      }
+      return stateData;
+    }
+    return null;
+  } catch (error) {
+    console.error("Error decoding state data:", error);
+    return null;
+  }
+};

--- a/signup-ui/src/utils/link.ts
+++ b/signup-ui/src/utils/link.ts
@@ -36,10 +36,6 @@ export const generateRandomString = (strLength = 16) => {
   return result;
 };
 
-export const generateState = () => {
-  return generateRandomString(16);
-}
-
 export const replaceUILocales = (
   hash: string,
   locale: string | null

--- a/signup-ui/src/utils/link.ts
+++ b/signup-ui/src/utils/link.ts
@@ -36,6 +36,10 @@ export const generateRandomString = (strLength = 16) => {
   return result;
 };
 
+export const generateState = () => {
+  return generateRandomString(16);
+}
+
 export const replaceUILocales = (
   hash: string,
   locale: string | null


### PR DESCRIPTION
- The user can initiate the verification flow either from the landing page or after completing registration. A button to start the verification process will be available on both pages.


- After the verification is successfully completed, a popup modal will appear. It will remain visible for a configurable duration (e.g., 10 seconds) before redirecting the user back to the page from which the flow was initiated—either the eSignet consent page or the signup landing page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Verify Identity" action in signup with a new "Proceed to Verification" button to start eKYC.
  * Support for relying-party OAuth/OIDC settings driving verification and sign-in redirects.
  * Auto-redirect after successful verification with visible countdown timer.

* **Behavior**
  * Unified dismissal/redirect handling across verification flows for consistent error and cancel behavior.

* **Localization**
  * Added/updated English and Khmer strings for verification and countdown messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->