### PR TITLE
ES-2739, ES-2796 - Updates CSRF token endpoint in eSignet-Signup API

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -8,7 +8,7 @@
 	<name>apitest-esignet-signup</name>
 	<description>Parent project of MOSIP e-signet signup apitests</description>
 	<url>https://github.com/mosip/esignet-signup</url>
-	<version>1.3.1-SNAPSHOT</version>
+	<version>1.4.0-SNAPSHOT</version>
 
 	<licenses>
 		<license>
@@ -61,7 +61,7 @@
 		<maven.source.plugin.version>2.2.1</maven.source.plugin.version>
 
 		<git.commit.id.plugin.version>3.0.1</git.commit.id.plugin.version>
-		<fileName>apitest-esignet-signup-1.3.1-SNAPSHOT-jar-with-dependencies</fileName>
+		<fileName>apitest-esignet-signup-1.4.0-SNAPSHOT-jar-with-dependencies</fileName>
 
 	</properties>
 
@@ -69,7 +69,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.4.0-SNAPSHOT</version>
+			<version>1.5.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 	<distributionManagement>

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testrunner/MosipTestRunner.java
@@ -117,6 +117,8 @@ public class MosipTestRunner {
 					SignupUtil.testCasesInRunScope = DependencyResolver.getDependencies(testCasesToExecuteString);
 				}
 				
+				AdminTestUtil.fetchAndStoreCsrfToken();
+				
 				startTestRunner();
 				
 				// Used for generating the test case interdependency JSON file
@@ -139,6 +141,8 @@ public class MosipTestRunner {
 				if (!testCasesToExecuteString.isBlank()) {
 					SignupUtil.testCasesInRunScope = DependencyResolver.getDependencies(testCasesToExecuteString);
 				}
+				
+				AdminTestUtil.fetchAndStoreCsrfToken();
 				
 				startTestRunner();
 				

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/utils/SignupUtil.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/utils/SignupUtil.java
@@ -1286,7 +1286,7 @@ public class SignupUtil extends AdminTestUtil {
 					.toString();
 
 		}
-		headers.put(XSRF_HEADERNAME, properties.getProperty(GlobalConstants.XSRFTOKEN));
+		headers.put(XSRF_HEADERNAME, BaseTestCase.CSRF_TOKEN);
 		headers.put(OAUTH_HASH_HEADERNAME, encodedResp);
 		headers.put(OAUTH_TRANSID_HEADERNAME, transactionId);
 		
@@ -1303,8 +1303,8 @@ public class SignupUtil extends AdminTestUtil {
 				|| BaseTestCase.currentModule.equals(GlobalConstants.RESIDENT)) {
 			inputJson = smtpOtpHandler(inputJson, testCaseName);
 		}
-
-		token = properties.getProperty(GlobalConstants.XSRFTOKEN);
+		
+		token = BaseTestCase.CSRF_COOKIE;
 		
 		if (request.has(GlobalConstants.IDV_TRANSACTION_ID)) {
 			headerTransactionID = request.get(GlobalConstants.IDV_TRANSACTION_ID).toString();

--- a/api-test/src/main/resources/config/application.properties
+++ b/api-test/src/main/resources/config/application.properties
@@ -79,7 +79,6 @@ passwordForAddIdentity=12341234_Aa
 passwordToReset=12341234_AaB
 
 ## Need to revisit these propeties
-#XSRFTOKEN=7d01b2a8-b89d-41ad-9361-d7f6294021d1
 codeChallenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
 codeVerifier=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
 policyNumberForSunBirdRC=326253801

--- a/api-test/src/main/resources/config/application.properties
+++ b/api-test/src/main/resources/config/application.properties
@@ -79,7 +79,7 @@ passwordForAddIdentity=12341234_Aa
 passwordToReset=12341234_AaB
 
 ## Need to revisit these propeties
-XSRFTOKEN=7d01b2a8-b89d-41ad-9361-d7f6294021d1
+#XSRFTOKEN=7d01b2a8-b89d-41ad-9361-d7f6294021d1
 codeChallenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
 codeVerifier=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
 policyNumberForSunBirdRC=326253801

--- a/api-test/src/main/resources/config/signup.properties
+++ b/api-test/src/main/resources/config/signup.properties
@@ -1,6 +1,7 @@
 #---------------------------------- End point(s) relative URLs ----------------------------------#
 actuatorEsignetEndpoint=/v1/esignet/actuator/env
 actuatorSignupEndpoint=/v1/signup/actuator/env
+csrfTokenEndpoint=/v1/esignet/csrf/token
 actuatorIdRepoEndpoint=/idrepository/v1/actuator/env
 tokenEndpoint=/v1/esignet/oauth/token
 esignetWellKnownEndPoint=/v1/esignet/oidc/.well-known/openid-configuration


### PR DESCRIPTION
Updated CSRF token endpoint in eSignet-Signup API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ensure a CSRF token is fetched and stored immediately before test execution to improve reliability.
  * Switch token handling to use internal constants for consistent CSRF header/cookie values.
  * Add configuration for a CSRF token endpoint.
  * Bump project version and related build metadata.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->