### PR TITLE
[ES-2511] The error message "The user account is blocked..." is getting truncated - FIXED

### DIFF
--- a/signup-ui/src/pages/ResetPasswordPage/Otp/Otp.tsx
+++ b/signup-ui/src/pages/ResetPasswordPage/Otp/Otp.tsx
@@ -346,7 +346,7 @@ export const Otp = ({ methods, settings }: OtpProps) => {
       <StepAlert>
         {/* Error message */}
         <ActionMessage hidden={!challengeVerificationError}>
-          <p className="truncate text-xs text-destructive">
+          <p className="text-xs text-destructive">
             {challengeVerificationError &&
               t(`error_response.${challengeVerificationError.errorCode}`)}
           </p>

--- a/signup-ui/src/pages/ResetPasswordPage/ResetPassword/ResetPassword.tsx
+++ b/signup-ui/src/pages/ResetPasswordPage/ResetPassword/ResetPassword.tsx
@@ -151,7 +151,7 @@ export const ResetPassword = ({ methods, settings }: ResetPasswordProps) => {
         <StepAlert className="relative">
           {/* Error message */}
           <ActionMessage hidden={!passwordResetError}>
-            <p className="truncate text-xs text-destructive">
+            <p className="text-xs text-destructive">
               {passwordResetError &&
                 t(`error_response.${passwordResetError.errorCode}`)}
             </p>

--- a/signup-ui/src/pages/ResetPasswordPage/UserInfo/UserInfo.tsx
+++ b/signup-ui/src/pages/ResetPasswordPage/UserInfo/UserInfo.tsx
@@ -241,7 +241,7 @@ export const UserInfo = ({ settings, methods }: UserInfoProps) => {
         <StepAlert className="relative">
           {/* Error message */}
           <ActionMessage hidden={!challengeGenerationError}>
-            <p className="truncate text-xs text-destructive">
+            <p className="text-xs text-destructive">
               {challengeGenerationError &&
                 t(`error_response.${challengeGenerationError.errorCode}`)}
             </p>

--- a/signup-ui/src/pages/SignUpPage/Otp/Otp.tsx
+++ b/signup-ui/src/pages/SignUpPage/Otp/Otp.tsx
@@ -341,7 +341,7 @@ export const Otp = ({ methods, settings }: OtpProps) => {
       <StepAlert>
         {/* Error message */}
         <ActionMessage hidden={!challengeVerificationError}>
-          <p className="truncate text-xs text-destructive">
+          <p className="text-xs text-destructive">
             {challengeVerificationError &&
               t(`error_response.${challengeVerificationError.errorCode}`)}
           </p>

--- a/signup-ui/src/pages/SignUpPage/Phone/Phone.tsx
+++ b/signup-ui/src/pages/SignUpPage/Phone/Phone.tsx
@@ -197,7 +197,7 @@ export const Phone = ({ settings, methods }: PhoneProps) => {
       <StepAlert className="relative">
         {/* Error message */}
         <ActionMessage hidden={!hasError}>
-          <p className="truncate text-xs text-destructive">
+          <p className="text-xs text-destructive">
             {error && t(`error_response.${error.errorCode}`)}
           </p>
           <Icons.close


### PR DESCRIPTION
Before: 
<img width="1069" height="1003" alt="image" src="https://github.com/user-attachments/assets/37ed33e4-6daf-4b22-adef-1f9d0ce84a28" />
After: 
<img width="1069" height="991" alt="image" src="https://github.com/user-attachments/assets/0f3267c5-5788-4d24-b6f4-3f3fd1413570" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages now wrap instead of being truncated on authentication pages, ensuring complete visibility of error text to users during sign-up and password reset flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->