### PR TITLE
MOSIP- 44419: Removed reflection-based TestNG method name modification.

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/AddIdentity.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/AddIdentity.java
@@ -211,17 +211,7 @@ public class AddIdentity extends SignupUtil implements ITest {
 	 */
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 
 	@AfterClass(alwaysRun = true)

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/GetWithParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/GetWithParam.java
@@ -188,16 +188,6 @@ public class GetWithParam extends SignupUtil implements ITest {
 	 */
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/PatchWithPathParamsAndBody.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/PatchWithPathParamsAndBody.java
@@ -131,16 +131,6 @@ public class PatchWithPathParamsAndBody extends SignupUtil implements ITest {
 	 */
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/PostWithAutogenIdWithOtpGenerate.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/PostWithAutogenIdWithOtpGenerate.java
@@ -236,17 +236,7 @@ public class PostWithAutogenIdWithOtpGenerate extends SignupUtil implements ITes
 	 */
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 
 	@AfterClass(alwaysRun = true)

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/PostWithOnlyPathParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/PostWithOnlyPathParam.java
@@ -150,16 +150,6 @@ public class PostWithOnlyPathParam extends SignupUtil implements ITest {
 	 */
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/PutWithPathParamsAndBody.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/PutWithPathParamsAndBody.java
@@ -181,16 +181,6 @@ public class PutWithPathParamsAndBody extends SignupUtil implements ITest {
 	 */
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/SimplePost.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/SimplePost.java
@@ -203,16 +203,6 @@ public class SimplePost extends SignupUtil implements ITest {
 	 */
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/SimplePostForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/SimplePostForAutoGenId.java
@@ -205,16 +205,6 @@ public class SimplePostForAutoGenId extends SignupUtil implements ITest {
 	 */
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/SimplePostForAutoGenIdForUrlEncoded.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/SimplePostForAutoGenIdForUrlEncoded.java
@@ -174,16 +174,6 @@ public class SimplePostForAutoGenIdForUrlEncoded extends SignupUtil implements I
 	 */
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/WebScocketConnection.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/WebScocketConnection.java
@@ -190,16 +190,6 @@ public class WebScocketConnection extends SignupUtil implements ITest {
 	 */
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
-		try {
-			Field method = TestResult.class.getDeclaredField("m_method");
-			method.setAccessible(true);
-			method.set(result, result.getMethod().clone());
-			BaseTestMethod baseTestMethod = (BaseTestMethod) result.getMethod();
-			Field f = baseTestMethod.getClass().getSuperclass().getDeclaredField("m_methodName");
-			f.setAccessible(true);
-			f.set(baseTestMethod, testCaseName);
-		} catch (Exception e) {
-			Reporter.log("Exception : " + e.getMessage());
-		}
+		result.setAttribute("TestCaseName", testCaseName);
 	}
 }


### PR DESCRIPTION
MOSIP- 44419: Removed reflection-based TestNG method name modification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified test result handling across multiple test scripts by replacing complex internal field manipulation with a streamlined metadata assignment approach. This improves code maintainability and removes unnecessary error handling while preserving test case name association with results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->