### PR TITLE
[DSD-9789] docker tag update.

### DIFF
--- a/docker-compose/dependent-docker-compose.yml
+++ b/docker-compose/dependent-docker-compose.yml
@@ -1,7 +1,6 @@
 services:
-
   database:
-    image: 'postgres:bookworm'
+    image: "postgres:bookworm"
     ports:
       - 5455:5432
     environment:
@@ -11,7 +10,7 @@ services:
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
 
   mock-identity-system:
-    image: 'mosipdev/mock-identity-system:develop'
+    image: "mosipdev/mock-identity-system:release-0.13.x"
     user: root
     ports:
       - 8082:8082
@@ -53,9 +52,8 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
 
-
   esignet:
-    image: 'mosipdev/esignet-with-plugins:develop'
+    image: "mosipdev/esignet-with-plugins:release-1.8.x"
     user: root
     ports:
       - 8088:8088
@@ -79,7 +77,7 @@ services:
       - mock-identity-system
 
   esignet-ui:
-    image: 'mosipdev/oidc-ui:develop'
+    image: "mosipdev/oidc-ui:release-1.8.x"
     user: root
     ports:
       - 3000:3000

--- a/signup-with-plugins/Dockerfile
+++ b/signup-with-plugins/Dockerfile
@@ -1,4 +1,4 @@
-FROM mosipdev/signup-service:develop
+FROM mosipdev/signup-service:release-1.4.x
 
 ARG SOURCE
 ARG COMMIT_HASH


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker service image references to use release versions instead of development versions, including mock-identity-system (0.13.x), esignet (1.8.x), OIDC UI (1.8.x), and signup service (1.4.x).
  * Standardized image reference formatting in Docker configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->