### PR TITLE
ES-2915 - Handle lookahead regex in schema-driven request generation to avoid Generex StackOverflow

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/PostWithAutogenIdWithOtpGenerate.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/testscripts/PostWithAutogenIdWithOtpGenerate.java
@@ -29,6 +29,7 @@ import io.mosip.testrig.apirig.testrunner.HealthChecker;
 import io.mosip.testrig.apirig.utils.AdminTestException;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
+import io.mosip.testrig.apirig.utils.NotificationListener;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
 import io.mosip.testrig.apirig.utils.SecurityXSSException;
@@ -132,6 +133,7 @@ public class PostWithAutogenIdWithOtpGenerate extends SignupUtil implements ITes
 		int currLoopCount = 0;
 		while (currLoopCount < maxLoopCount) {
 			String input = inputstringKeyWordHandeler(inputStrJson, testCaseName);
+			NotificationListener.markRequestStart();
 			if (testCaseName.contains(GlobalConstants.ESIGNET_)) {
 				if (SignupConfigManager.isInServiceNotDeployedList(GlobalConstants.ESIGNET)) {
 					throw new SkipException("esignet is not deployed hence skipping the testcase");
@@ -237,6 +239,8 @@ public class PostWithAutogenIdWithOtpGenerate extends SignupUtil implements ITes
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
 		result.setAttribute("TestCaseName", testCaseName);
+		// Always cleanup watermark
+		NotificationListener.markRequestRemove();
 	}
 
 	@AfterClass(alwaysRun = true)

--- a/api-test/src/main/java/io/mosip/testrig/apirig/signup/utils/SignupUtil.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/signup/utils/SignupUtil.java
@@ -53,6 +53,7 @@ import io.mosip.testrig.apirig.utils.GlobalMethods;
 import io.mosip.testrig.apirig.utils.JWKKeyUtil;
 import io.mosip.testrig.apirig.utils.KernelAuthentication;
 import io.mosip.testrig.apirig.utils.KeycloakUserManager;
+import io.mosip.testrig.apirig.utils.NotificationListener;
 import io.mosip.testrig.apirig.utils.RestClient;
 import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.mosip.testrig.apirig.utils.SkipTestCaseHandler;
@@ -554,7 +555,7 @@ public class SignupUtil extends AdminTestUtil {
 						emailId = removeLeadingPlusSigns(emailId);
 					}
 					logger.info(emailId);
-					otp = OTPListener.getOtp(emailId);
+					otp = NotificationListener.getOtp(emailId);
 					request.getJSONObject(GlobalConstants.REQUEST).put("otp", otp);
 					inputJson = request.toString();
 					return inputJson;
@@ -580,7 +581,7 @@ public class SignupUtil extends AdminTestUtil {
 									emailId = removeLeadingPlusSigns(emailId);
 								}
 								logger.info(emailId);
-								otp = OTPListener.getOtp(emailId);
+								otp = NotificationListener.getOtp(emailId);
 								request.getJSONObject(GlobalConstants.REQUEST)
 										.getJSONArray(GlobalConstants.CHALLENGELIST).getJSONObject(0)
 										.put(GlobalConstants.CHALLENGE, otp);
@@ -1704,7 +1705,7 @@ public class SignupUtil extends AdminTestUtil {
 					String regex = field.get(SignupConstants.VALIDATORS_STRING).get(0).path(SignupConstants.REGEX)
 							.asText(null);
 
-					if (regex != null) {
+					if (regex != null && !regex.contains("(?")) {
 						if (regex.contains(SignupConstants.AT_SYMBOL)) {
 							userInfo.put(id, SignupConstants.TEST_AUTOMATION_EMAIL);
 						} else {

--- a/ui-test/pom.xml
+++ b/ui-test/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mosip.signup</groupId>
 	<artifactId>uitest-signup</artifactId>
-	<version>1.3.1-SNAPSHOT</version>
+	<version>1.4.0-SNAPSHOT</version>
 
 	<name>uitest-esignet</name>
 	<url>https://github.com/mosip/esignet</url>
@@ -162,7 +162,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.3.5-SNAPSHOT</version>
+			<version>1.3.6</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>


### PR DESCRIPTION
Updated the regex handling logic to skip regex generation for patterns containing advanced constructs ((?).
This prevents Generex from processing unsupported regex patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OTP retrieval during signup tests to increase reliability.
  * Ensured per-test cleanup to avoid leftover test artifacts affecting subsequent runs.
  * Tightened request pattern handling to skip certain regex cases during registration scenarios.

* **Chores**
  * Project version and related test-library dependency updated to a new snapshot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->