### PR TITLE
ES-2932 | Support email and SMS notification channels during registration and reset-password

### DIFF
--- a/signup-service/src/main/java/io/mosip/signup/helper/NotificationHelper.java
+++ b/signup-service/src/main/java/io/mosip/signup/helper/NotificationHelper.java
@@ -61,56 +61,15 @@ public class NotificationHelper {
     @Value("${mosip.signup.sms-notification.remove-country-code:false}")
     private boolean removeCountryCode;
 
-    @Value("${mosip.signup.send-notification.channel}")
+    @Value("${mosip.signup.send-notification.channel:sms}")
     private String defaultChannel;
 
     public void sendNotification(String identifier, String locale, String templateKey, Map<String, String> params) {
         locale = locale != null ? locale : defaultLanguage;
-        boolean isEncoded = encodedLangCodes.contains(locale);
-
         if (EMAIL_CHANNEL.equalsIgnoreCase(defaultChannel)) {
-            String subject = resolveTemplate(EMAIL_SUBJECT_PROPERTY_PREFIX + templateKey + "." + locale, isEncoded, params);
-            String content = resolveTemplate(EMAIL_CONTENT_PROPERTY_PREFIX + templateKey + "." + locale, isEncoded, params);
-
-            // multipart/form-data
-            HttpHeaders headers = new HttpHeaders();
-            headers.setContentType(MediaType.MULTIPART_FORM_DATA);
-            MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
-            formData.add("mailTo", identifier);
-            formData.add("mailSubject", subject);
-            formData.add("mailContent", content);
-
-            try {
-                RestResponseWrapper<NotificationResponse> responseWrapper = selfTokenRestTemplate.exchange(sendNotificationEndpoint, HttpMethod.POST, new HttpEntity<>(formData, headers), new ParameterizedTypeReference<RestResponseWrapper<NotificationResponse>>() {
-                }).getBody();
-                log.debug("Email notification response -> {}", responseWrapper);
-            } catch (RestClientException e) {
-                log.error("Failed to send email notification for identifier {}", identifier, e);
-                throw new SignUpException(ErrorConstants.OTP_NOTIFICATION_FAILED);
-            }
-
+            sendEmailNotification(identifier, locale, templateKey, params);
         } else if (SMS_CHANNEL.equalsIgnoreCase(defaultChannel)) {
-            String message = resolveTemplate(SMS_TEMPLATE_PROPERTY_PREFIX + templateKey + "." + locale, isEncoded, params);
-
-            String phoneNumber = identifier;
-
-            if (removeCountryCode && identifier.startsWith(identifierPrefix)) {
-                phoneNumber = identifier.substring(identifierPrefix.length());
-            }
-
-            NotificationRequest notificationRequest = new NotificationRequest(phoneNumber, message);
-            RestRequestWrapper<NotificationRequest> restRequestWrapper = new RestRequestWrapper<>();
-            restRequestWrapper.setRequesttime(IdentityProviderUtil.getUTCDateTime());
-            restRequestWrapper.setRequest(notificationRequest);
-
-            try {
-                RestResponseWrapper<NotificationResponse> responseWrapper = selfTokenRestTemplate.exchange(sendNotificationEndpoint, HttpMethod.POST, new HttpEntity<>(restRequestWrapper), new ParameterizedTypeReference<RestResponseWrapper<NotificationResponse>>() {
-                }).getBody();
-                log.debug("SMS notification response -> {}", responseWrapper);
-            } catch (RestClientException e) {
-                log.error("Failed to send SMS notification for identifier {}", identifier, e);
-                throw new SignUpException(ErrorConstants.OTP_NOTIFICATION_FAILED);
-            }
+            sendSMSNotification(identifier, locale, templateKey, params);
         } else {
             log.error("Unsupported notification channel configured: {}", defaultChannel);
             throw new SignUpException(ErrorConstants.INVALID_NOTIFICATION_CHANNEL);
@@ -120,6 +79,55 @@ public class NotificationHelper {
     @Async
     public void sendNotificationAsync(String identifier, String locale, String templateKey, Map<String, String> params) {
         sendNotification(identifier, locale, templateKey, params);
+    }
+
+    private void sendEmailNotification(String identifier, String locale, String templateKey, Map<String, String> params) {
+        boolean isEncoded = encodedLangCodes.contains(locale);
+        String subject = resolveTemplate(EMAIL_SUBJECT_PROPERTY_PREFIX + templateKey + "." + locale, isEncoded, params);
+        String content = resolveTemplate(EMAIL_CONTENT_PROPERTY_PREFIX + templateKey + "." + locale, isEncoded, params);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("mailTo", identifier);
+        formData.add("mailSubject", subject);
+        formData.add("mailContent", content);
+        try {
+            RestResponseWrapper<NotificationResponse> responseWrapper = selfTokenRestTemplate.exchange(sendNotificationEndpoint, HttpMethod.POST, new HttpEntity<>(formData, headers), new ParameterizedTypeReference<RestResponseWrapper<NotificationResponse>>() {
+            }).getBody();
+            validateResponse(responseWrapper, "Email");
+        } catch (RestClientException e) {
+            log.error("Failed to send email notification", e);
+            throw new SignUpException(ErrorConstants.OTP_NOTIFICATION_FAILED);
+        }
+    }
+
+    private void sendSMSNotification(String identifier, String locale, String templateKey, Map<String, String> params) {
+        boolean isEncoded = encodedLangCodes.contains(locale);
+        String message = resolveTemplate(SMS_TEMPLATE_PROPERTY_PREFIX + templateKey + "." + locale, isEncoded, params);
+        String phoneNumber = identifier;
+        if (removeCountryCode && identifier.startsWith(identifierPrefix)) {
+            phoneNumber = identifier.substring(identifierPrefix.length());
+        }
+        NotificationRequest notificationRequest = new NotificationRequest(phoneNumber, message);
+        RestRequestWrapper<NotificationRequest> restRequestWrapper = new RestRequestWrapper<>();
+        restRequestWrapper.setRequesttime(IdentityProviderUtil.getUTCDateTime());
+        restRequestWrapper.setRequest(notificationRequest);
+        try {
+            RestResponseWrapper<NotificationResponse> responseWrapper = selfTokenRestTemplate.exchange(sendNotificationEndpoint, HttpMethod.POST, new HttpEntity<>(restRequestWrapper), new ParameterizedTypeReference<RestResponseWrapper<NotificationResponse>>() {
+            }).getBody();
+            validateResponse(responseWrapper, "SMS");
+        } catch (RestClientException e) {
+            log.error("Failed to send SMS notification", e);
+            throw new SignUpException(ErrorConstants.OTP_NOTIFICATION_FAILED);
+        }
+    }
+
+    private void validateResponse(RestResponseWrapper<NotificationResponse> responseWrapper, String channel) {
+        if (responseWrapper == null || (responseWrapper.getErrors() != null && !responseWrapper.getErrors().isEmpty())) {
+            log.error("{} notification failed. Response: {}", channel, responseWrapper);
+            throw new SignUpException(ErrorConstants.OTP_NOTIFICATION_FAILED);
+        }
+        log.debug("{} notification response -> {}", channel, responseWrapper);
     }
 
     private String resolveTemplate(String templateKey, boolean isEncoded, Map<String, String> params) {

--- a/signup-service/src/main/java/io/mosip/signup/helper/NotificationHelper.java
+++ b/signup-service/src/main/java/io/mosip/signup/helper/NotificationHelper.java
@@ -85,14 +85,18 @@ public class NotificationHelper {
                 }).getBody();
                 log.debug("Email notification response -> {}", responseWrapper);
             } catch (RestClientException e) {
-                log.error("Failed to send email notification", e);
+                log.error("Failed to send email notification for identifier {}", identifier, e);
                 throw new SignUpException(ErrorConstants.OTP_NOTIFICATION_FAILED);
             }
 
-        } else {
+        } else if (SMS_CHANNEL.equalsIgnoreCase(defaultChannel)) {
             String message = resolveTemplate(SMS_TEMPLATE_PROPERTY_PREFIX + templateKey + "." + locale, isEncoded, params);
 
-            String phoneNumber = removeCountryCode ? identifier.substring(identifierPrefix.length()) : identifier;
+            String phoneNumber = identifier;
+
+            if (removeCountryCode && identifier.startsWith(identifierPrefix)) {
+                phoneNumber = identifier.substring(identifierPrefix.length());
+            }
 
             NotificationRequest notificationRequest = new NotificationRequest(phoneNumber, message);
             RestRequestWrapper<NotificationRequest> restRequestWrapper = new RestRequestWrapper<>();
@@ -104,9 +108,12 @@ public class NotificationHelper {
                 }).getBody();
                 log.debug("SMS notification response -> {}", responseWrapper);
             } catch (RestClientException e) {
-                log.error("Failed to send SMS notification", e);
+                log.error("Failed to send SMS notification for identifier {}", identifier, e);
                 throw new SignUpException(ErrorConstants.OTP_NOTIFICATION_FAILED);
             }
+        } else {
+            log.error("Unsupported notification channel configured: {}", defaultChannel);
+            throw new SignUpException(ErrorConstants.INVALID_NOTIFICATION_CHANNEL);
         }
     }
 
@@ -116,9 +123,20 @@ public class NotificationHelper {
     }
 
     private String resolveTemplate(String templateKey, boolean isEncoded, Map<String, String> params) {
-        String template = isEncoded ? new String(Base64.getDecoder().decode(environment.getProperty(templateKey))) : environment.getProperty(templateKey);
+        String rawTemplate = environment.getProperty(templateKey);
+        if (rawTemplate == null) {
+            log.error("Notification template not configured: {}", templateKey);
+            throw new SignUpException(ErrorConstants.NOTIFICATION_TEMPLATE_NOT_FOUND);
+        }
 
-        if (params != null && template != null) {
+        String template;
+        try {
+            template = isEncoded ? new String(Base64.getDecoder().decode(rawTemplate)) : rawTemplate;
+        } catch (IllegalArgumentException e) {
+            log.error("Invalid encoded notification template: {}", templateKey, e);
+            throw new SignUpException(ErrorConstants.NOTIFICATION_TEMPLATE_NOT_FOUND);
+        }
+        if (params != null) {
             for (Map.Entry<String, String> entry : params.entrySet()) {
                 template = template.replace(entry.getKey(), entry.getValue());
             }

--- a/signup-service/src/main/java/io/mosip/signup/helper/NotificationHelper.java
+++ b/signup-service/src/main/java/io/mosip/signup/helper/NotificationHelper.java
@@ -24,10 +24,16 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+
+import static io.mosip.signup.util.SignUpConstants.*;
 
 @Slf4j
 @Component
@@ -46,50 +52,77 @@ public class NotificationHelper {
     @Value("${mosip.signup.default-language}")
     private String defaultLanguage;
 
-    @Value("#{${mosip.signup.sms-notification-template.encoded-langcodes}}")
+    @Value("#{${mosip.signup.notification-template.encoded-langcodes}}")
     private List<String> encodedLangCodes;
 
     @Value("${mosip.signup.identifier.prefix:}")
     private String identifierPrefix;
 
-    @Value("${mosip.signup.identifier.remove-prefix:false}")
-    private boolean removeIdentifierPrefix;
+    @Value("${mosip.signup.sms-notification.remove-country-code:false}")
+    private boolean removeCountryCode;
 
-    public void sendSMSNotification
-            (String number, String locale, String templateKey, Map<String, String> params){
+    @Value("${mosip.signup.send-notification.channel}")
+    private String defaultChannel;
 
+    public void sendNotification(String identifier, String locale, String templateKey, Map<String, String> params) {
         locale = locale != null ? locale : defaultLanguage;
+        boolean isEncoded = encodedLangCodes.contains(locale);
 
-        String message = encodedLangCodes.contains(locale)?
-                new String(Base64.getDecoder().decode(environment.getProperty(templateKey + "." + locale))):
-                environment.getProperty(templateKey + "." + locale);
+        if (EMAIL_CHANNEL.equalsIgnoreCase(defaultChannel)) {
+            String subject = resolveTemplate(EMAIL_SUBJECT_PROPERTY_PREFIX + templateKey + "." + locale, isEncoded, params);
+            String content = resolveTemplate(EMAIL_CONTENT_PROPERTY_PREFIX + templateKey + "." + locale, isEncoded, params);
 
-        if (params != null && message != null) {
-            for (Map.Entry<String, String> entry : params.entrySet()) {
-                message = message.replace(entry.getKey(), entry.getValue());
+            // multipart/form-data
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+            MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+            formData.add("mailTo", identifier);
+            formData.add("mailSubject", subject);
+            formData.add("mailContent", content);
+
+            try {
+                RestResponseWrapper<NotificationResponse> responseWrapper = selfTokenRestTemplate.exchange(sendNotificationEndpoint, HttpMethod.POST, new HttpEntity<>(formData, headers), new ParameterizedTypeReference<RestResponseWrapper<NotificationResponse>>() {
+                }).getBody();
+                log.debug("Email notification response -> {}", responseWrapper);
+            } catch (RestClientException e) {
+                log.error("Failed to send email notification", e);
+                throw new SignUpException(ErrorConstants.OTP_NOTIFICATION_FAILED);
             }
-        }
-        String phoneNumber = removeIdentifierPrefix ? number.substring(identifierPrefix.length()) : number;
-        NotificationRequest notificationRequest = new NotificationRequest(phoneNumber, message);
 
-        RestRequestWrapper<NotificationRequest> restRequestWrapper = new RestRequestWrapper<>();
-        restRequestWrapper.setRequesttime(IdentityProviderUtil.getUTCDateTime());
-        restRequestWrapper.setRequest(notificationRequest);
+        } else {
+            String message = resolveTemplate(SMS_TEMPLATE_PROPERTY_PREFIX + templateKey + "." + locale, isEncoded, params);
 
-        try {
-            RestResponseWrapper<NotificationResponse> responseWrapper = selfTokenRestTemplate.exchange(sendNotificationEndpoint,
-                    HttpMethod.POST,
-                    new HttpEntity<>(restRequestWrapper),
-                    new ParameterizedTypeReference<RestResponseWrapper<NotificationResponse>>(){}).getBody();
-            log.debug("Notification response -> {}", responseWrapper);
-        } catch (RestClientException e){
-            throw new SignUpException(ErrorConstants.OTP_NOTIFICATION_FAILED);
+            String phoneNumber = removeCountryCode ? identifier.substring(identifierPrefix.length()) : identifier;
+
+            NotificationRequest notificationRequest = new NotificationRequest(phoneNumber, message);
+            RestRequestWrapper<NotificationRequest> restRequestWrapper = new RestRequestWrapper<>();
+            restRequestWrapper.setRequesttime(IdentityProviderUtil.getUTCDateTime());
+            restRequestWrapper.setRequest(notificationRequest);
+
+            try {
+                RestResponseWrapper<NotificationResponse> responseWrapper = selfTokenRestTemplate.exchange(sendNotificationEndpoint, HttpMethod.POST, new HttpEntity<>(restRequestWrapper), new ParameterizedTypeReference<RestResponseWrapper<NotificationResponse>>() {
+                }).getBody();
+                log.debug("SMS notification response -> {}", responseWrapper);
+            } catch (RestClientException e) {
+                log.error("Failed to send SMS notification", e);
+                throw new SignUpException(ErrorConstants.OTP_NOTIFICATION_FAILED);
+            }
         }
     }
 
     @Async
-    public void sendSMSNotificationAsync
-            (String number, String locale, String templateKey, Map<String, String> params){
-        sendSMSNotification(number, locale, templateKey, params);
+    public void sendNotificationAsync(String identifier, String locale, String templateKey, Map<String, String> params) {
+        sendNotification(identifier, locale, templateKey, params);
+    }
+
+    private String resolveTemplate(String templateKey, boolean isEncoded, Map<String, String> params) {
+        String template = isEncoded ? new String(Base64.getDecoder().decode(environment.getProperty(templateKey))) : environment.getProperty(templateKey);
+
+        if (params != null && template != null) {
+            for (Map.Entry<String, String> entry : params.entrySet()) {
+                template = template.replace(entry.getKey(), entry.getValue());
+            }
+        }
+        return template;
     }
 }

--- a/signup-service/src/main/java/io/mosip/signup/helper/NotificationHelper.java
+++ b/signup-service/src/main/java/io/mosip/signup/helper/NotificationHelper.java
@@ -52,6 +52,9 @@ public class NotificationHelper {
     @Value("${mosip.signup.identifier.prefix:}")
     private String identifierPrefix;
 
+    @Value("${mosip.signup.identifier.remove-prefix:false}")
+    private boolean removeIdentifierPrefix;
+
     public void sendSMSNotification
             (String number, String locale, String templateKey, Map<String, String> params){
 
@@ -66,8 +69,8 @@ public class NotificationHelper {
                 message = message.replace(entry.getKey(), entry.getValue());
             }
         }
-
-        NotificationRequest notificationRequest = new NotificationRequest(number.substring(identifierPrefix.length()), message);
+        String phoneNumber = removeIdentifierPrefix ? number.substring(identifierPrefix.length()) : number;
+        NotificationRequest notificationRequest = new NotificationRequest(phoneNumber, message);
 
         RestRequestWrapper<NotificationRequest> restRequestWrapper = new RestRequestWrapper<>();
         restRequestWrapper.setRequesttime(IdentityProviderUtil.getUTCDateTime());

--- a/signup-service/src/main/java/io/mosip/signup/helper/NotificationHelper.java
+++ b/signup-service/src/main/java/io/mosip/signup/helper/NotificationHelper.java
@@ -43,7 +43,7 @@ public class NotificationHelper {
     @Value("${mosip.signup.send-notification.endpoint}")
     private String sendNotificationEndpoint;
 
-    @Value("{${mosip.signup.default-language}")
+    @Value("${mosip.signup.default-language}")
     private String defaultLanguage;
 
     @Value("#{${mosip.signup.sms-notification-template.encoded-langcodes}}")

--- a/signup-service/src/main/java/io/mosip/signup/services/RegistrationService.java
+++ b/signup-service/src/main/java/io/mosip/signup/services/RegistrationService.java
@@ -147,8 +147,8 @@ public class RegistrationService {
 
         HashMap<String, String> hashMap = new LinkedHashMap<>();
         hashMap.put("{challenge}", challenge);
-        notificationHelper.sendSMSNotification(generateChallengeRequest.getIdentifier(), transaction.getLocale(),
-                SEND_OTP_SMS_NOTIFICATION_TEMPLATE_KEY, hashMap);
+        notificationHelper.sendNotification(generateChallengeRequest.getIdentifier(), transaction.getLocale(),
+                SEND_OTP_TEMPLATE_KEY, hashMap);
         return new GenerateChallengeResponse(ActionStatus.SUCCESS);
     }
 
@@ -244,8 +244,8 @@ public class RegistrationService {
         cacheUtilService.setStatusCheckTransaction(transactionId, transaction);
 
         String locale = registerRequest.getLocale() == null ? transaction.getLocale() : registerRequest.getLocale();
-        notificationHelper.sendSMSNotificationAsync(registerRequest.getUsername(), locale,
-                REGISTRATION_SMS_NOTIFICATION_TEMPLATE_KEY, null);
+        notificationHelper.sendNotificationAsync(registerRequest.getUsername(), locale,
+                REGISTRATION_TEMPLATE_KEY, null);
 
         RegisterResponse registration = new RegisterResponse();
         registration.setStatus(ActionStatus.PENDING);
@@ -284,8 +284,8 @@ public class RegistrationService {
         cacheUtilService.setStatusCheckTransaction(transactionId, transaction);
 
         String locale = resetPasswordRequest.getLocale() == null ? transaction.getLocale() : resetPasswordRequest.getLocale();
-        notificationHelper.sendSMSNotificationAsync(resetPasswordRequest.getIdentifier(), locale,
-                FORGOT_PASSWORD_SMS_NOTIFICATION_TEMPLATE_KEY, null);
+        notificationHelper.sendNotificationAsync(resetPasswordRequest.getIdentifier(), locale,
+                FORGOT_PASSWORD_TEMPLATE_KEY, null);
 
         RegistrationStatusResponse resetPassword = new RegistrationStatusResponse();
         resetPassword.setStatus(ProfileCreateUpdateStatus.PENDING);

--- a/signup-service/src/main/java/io/mosip/signup/util/ErrorConstants.java
+++ b/signup-service/src/main/java/io/mosip/signup/util/ErrorConstants.java
@@ -40,6 +40,8 @@ public class ErrorConstants {
     public static final String KNOWLEDGEBASE_MISMATCH = "knowledgebase_mismatch";
     public static final String IDENTIFIER_BLOCKED = "identifier_blocked";
     public static final String OTP_NOTIFICATION_FAILED = "otp_notification_failed";
+    public static final String INVALID_NOTIFICATION_CHANNEL = "invalid_notification_channel";
+    public static final String NOTIFICATION_TEMPLATE_NOT_FOUND = "notification_template_not_found";
     public static final String SERVER_UNREACHABLE = "server_unreachable";
 
     public static final String INVALID_IDENTITY_VERIFIER_ID = "invalid_identity_verifier_id";

--- a/signup-service/src/main/java/io/mosip/signup/util/SignUpConstants.java
+++ b/signup-service/src/main/java/io/mosip/signup/util/SignUpConstants.java
@@ -24,15 +24,19 @@ public class SignUpConstants {
     public static final String IDV_SLOT_ALLOTTED = "IDV_SLOT_ALLOTTED";
     public static final String CONSENT_AGREE = "AGREE";
     public static final String EMTPY = "";
-    public static final String SEND_OTP_SMS_NOTIFICATION_TEMPLATE_KEY = "mosip.signup.sms-notification-template.send-otp";
-    public static final String REGISTRATION_SMS_NOTIFICATION_TEMPLATE_KEY = "mosip.signup.sms-notification-template.registration";
-    public static final String FORGOT_PASSWORD_SMS_NOTIFICATION_TEMPLATE_KEY = "mosip.signup.sms-notification-template.forgot-password";
+    public static final String SEND_OTP_TEMPLATE_KEY = "send-otp";
+    public static final String REGISTRATION_TEMPLATE_KEY = "registration";
+    public static final String FORGOT_PASSWORD_TEMPLATE_KEY = "forgot-password";
+    public static final String SMS_TEMPLATE_PROPERTY_PREFIX = "mosip.signup.sms-notification-template.";
+    public static final String EMAIL_SUBJECT_PROPERTY_PREFIX = "mosip.signup.email-notification-template.subject.";
+    public static final String EMAIL_CONTENT_PROPERTY_PREFIX = "mosip.signup.email-notification-template.content.";
     public static final String ACTIVATED = "ACTIVATED";
-
     public static final String SLOTS_CONNECTED = "slots_connected";
     public static final String SLOT_ALLOTTED = "slot_allotted";
     public static final String VERIFIED_SLOT = "verified_slot";
     public static final String VALUE_SEPARATOR = "###";
     public static final String UI_SPEC = "ui_spec";
+    public static final String EMAIL_CHANNEL = "email";
+    public static final String SMS_CHANNEL = "sms";
 
 }

--- a/signup-service/src/main/resources/application-default.properties
+++ b/signup-service/src/main/resources/application-default.properties
@@ -6,6 +6,7 @@ mosip.signup.namespace=${NAMESPACE:esignet}
 
 ## challenge.timeout, resend-delay are count as seconds
 mosip.signup.identifier.regex=^\\+91[1-9]\\d{7,8}$
+mosip.signup.identifier.remove-prefix=false
 mosip.signup.identifier.prefix=+91
 mosip.signup.supported-languages={'eng'}
 mosip.signup.default-language=eng

--- a/signup-service/src/main/resources/application-default.properties
+++ b/signup-service/src/main/resources/application-default.properties
@@ -6,7 +6,7 @@ mosip.signup.namespace=${NAMESPACE:esignet}
 
 ## challenge.timeout, resend-delay are count as seconds
 mosip.signup.identifier.regex=^\\+91[1-9]\\d{7,8}$
-mosip.signup.identifier.remove-prefix=false
+mosip.signup.sms-notification.remove-country-code=false
 mosip.signup.identifier.prefix=+91
 mosip.signup.supported-languages={'eng'}
 mosip.signup.default-language=eng
@@ -169,7 +169,14 @@ mosip.security.cors-enable=true
 ## -------------------------- External endpoints -----------------------------------------------------------------------
 
 mosip.signup.generate-challenge.endpoint=http://otpmanager.kernel/v1/otpmanager/otp/generate
-mosip.signup.send-notification.endpoint=http://notifier.kernel/v1/notifier/sms/send
+
+## Notification channel configuration
+## Specifies the channel to use for sending notifications.
+## Allowed values:
+# sms   - Send notifications via SMS (default)
+# email - Send notifications via email
+mosip.signup.send-notification.channel=sms
+mosip.signup.send-notification.endpoint=http://notifier.kernel/v1/notifier/${mosip.signup.send-notification.channel}/send
 mosip.signup.audit-endpoint=http://auditmanager.kernel/v1/auditmanager/audits
 
 ## --------------------------------- captcha validator------------------------------------------------------------------
@@ -233,13 +240,28 @@ mosip.signup.ui.config.key-values={\
 ## ----------------------------- Notification templates -----------------------------------------------------------------------------
 
 # Default charset encoding ISO-8859-1 does not support khmer language characters, so templates in khm language are base64 encoded.
-mosip.signup.sms-notification-template.encoded-langcodes={'khm'}
+mosip.signup.notification-template.encoded-langcodes={'khm'}
 mosip.signup.sms-notification-template.send-otp.khm=4Z6U4Z+S4Z6a4Z6+IHtjaGFsbGVuZ2V9IOGeiuGevuGemOGfkuGelOGeuOGeleGfkuGekeGfgOGehOGeleGfkuGekeGetuGej+Gfi+GeguGejuGek+GeuCBLaElEIOGemuGelOGen+Gfi+GeouGfkuGek+GegOGflA==
 mosip.signup.sms-notification-template.send-otp.eng=Use {challenge} to verify your KhID account.
 mosip.signup.sms-notification-template.registration.khm=4Z6i4Z+S4Z6T4Z6A4Z6U4Z624Z6T4Z6F4Z674Z+H4Z6I4Z+S4Z6Y4Z+E4Z+H4Z6C4Z6O4Z6T4Z64IEtoSUQg4Z6K4Z+E4Z6Z4Z6H4Z+E4Z6C4Z6H4Z+Q4Z6Z4Z+U
 mosip.signup.sms-notification-template.registration.eng=You successfully registered to KhID account.
 mosip.signup.sms-notification-template.forgot-password.khm=4Z6i4Z+S4Z6T4Z6A4Z6U4Z624Z6T4Z6V4Z+S4Z6b4Z624Z6f4Z+L4Z6U4Z+S4Z6K4Z684Z6a4Z6W4Z624Z6A4Z+S4Z6Z4Z6f4Z6Y4Z+S4Z6E4Z624Z6P4Z+LIEtoSUQg4Z6K4Z+E4Z6Z4Z6H4Z+E4Z6C4Z6H4Z+Q4Z6Z4Z+U
 mosip.signup.sms-notification-template.forgot-password.eng=You successfully changed KhID password.
+
+mosip.signup.email-notification-template.subject.send-otp.eng=OTP Verification
+mosip.signup.email-notification-template.subject.send-otp.khm=4Z6b4Z+B4Z6B4Z6A4Z684Z6K4Z6V4Z+S4Z6R4Z+A4Z6E4Z6V4Z+S4Z6R4Z624Z6P4Z+L
+mosip.signup.email-notification-template.content.send-otp.eng=Use {challenge} to verify your account.
+mosip.signup.email-notification-template.content.send-otp.khm=4Z6f4Z684Z6Y4Z6U4Z+S4Z6a4Z6+4Z6b4Z+B4Z6B4Z6A4Z684Z6KIHtjaGFsbGVuZ2V9IOGeiuGevuGemOGfkuGelOGeuOGeleGfkuGekeGfgOGehOGeleGfkuGekeGetuGej+Gfi+GeguGejuGek+GeuOGemuGelOGen+Gfi+GeouGfkuGek+GegOGflA==
+
+mosip.signup.email-notification-template.subject.registration.eng=Registration Successful
+mosip.signup.email-notification-template.subject.registration.khm=4Z6A4Z624Z6a4Z6F4Z674Z+H4Z6I4Z+S4Z6Y4Z+E4Z+H4Z6U4Z624Z6T4Z6H4Z+E4Z6C4Z6H4Z+Q4Z6Z
+mosip.signup.email-notification-template.content.registration.eng=You have successfully registered your account.
+mosip.signup.email-notification-template.content.registration.khm=4Z6i4Z+S4Z6T4Z6A4Z6U4Z624Z6T4Z6F4Z674Z+H4Z6I4Z+S4Z6Y4Z+E4Z+H4Z6C4Z6O4Z6T4Z644Z6a4Z6U4Z6f4Z+L4Z6i4Z+S4Z6T4Z6A4Z6K4Z+E4Z6Z4Z6H4Z+E4Z6C4Z6H4Z+Q4Z6Z4Z+U
+
+mosip.signup.email-notification-template.subject.forgot-password.eng=Password Changed
+mosip.signup.email-notification-template.subject.forgot-password.khm=4Z6W4Z624Z6A4Z+S4Z6Z4Z6f4Z6Y4Z+S4Z6E4Z624Z6P4Z+L4Z6U4Z624Z6T4Z6V4Z+S4Z6b4Z624Z6f4Z+L4Z6U4Z+S4Z6P4Z684Z6a
+mosip.signup.email-notification-template.content.forgot-password.eng=Your password has been successfully changed.
+mosip.signup.email-notification-template.content.forgot-password.khm=4Z6W4Z624Z6A4Z+S4Z6Z4Z6f4Z6Y4Z+S4Z6E4Z624Z6P4Z+L4Z6a4Z6U4Z6f4Z+L4Z6i4Z+S4Z6T4Z6A4Z6P4Z+S4Z6a4Z684Z6c4Z6U4Z624Z6T4Z6V4Z+S4Z6b4Z624Z6f4Z+L4Z6U4Z+S4Z6P4Z684Z6a4Z6K4Z+E4Z6Z4Z6H4Z+E4Z6C4Z6H4Z+Q4Z6Z4Z+U
 
 ## Kafka configurations
 kafka.profile=kafka.svc.cluster.local

--- a/signup-service/src/main/resources/application-local.properties
+++ b/signup-service/src/main/resources/application-local.properties
@@ -36,7 +36,7 @@ mosip.signup.oauth.keystore-password=signup-oidc-password
 
 ## Validators w.r.t MOCK plugin
 mosip.signup.identifier.regex=^\\+855[1-9]\\d{7,8}$
-mosip.signup.identifier.remove-prefix=false
+mosip.signup.sms-notification.remove-country-code=false
 mosip.signup.identifier.prefix=+855
 mosip.signup.supported-languages={'eng','khm'}
 

--- a/signup-service/src/main/resources/application-local.properties
+++ b/signup-service/src/main/resources/application-local.properties
@@ -13,7 +13,8 @@ keycloak.external.url=https://iam.env-name.mosip.net
 mosip.signup.client.secret=secret-from-env
 
 mosip.signup.generate-challenge.endpoint=${mosip.internal.domain.url}/v1/otpmanager/otp/generate
-mosip.signup.send-notification.endpoint=${mosip.internal.domain.url}/v1/notifier/sms/send
+mosip.signup.send-notification.channel=sms
+mosip.signup.send-notification.endpoint=${mosip.internal.domain.url}/v1/notifier/${mosip.signup.send-notification.channel}/send
 mosip.signup.audit-endpoint=${mosip.internal.domain.url}/v1/auditmanager/audits
 mosip.signup.oauth.token-uri=${mosip.esignet.domain.url}/v1/esignet/oauth/v2/token
 mosip.signup.oauth.userinfo-uri=${mosip.esignet.domain.url}/v1/esignet/oidc/userinfo

--- a/signup-service/src/main/resources/application-local.properties
+++ b/signup-service/src/main/resources/application-local.properties
@@ -36,6 +36,7 @@ mosip.signup.oauth.keystore-password=signup-oidc-password
 
 ## Validators w.r.t MOCK plugin
 mosip.signup.identifier.regex=^\\+855[1-9]\\d{7,8}$
+mosip.signup.identifier.remove-prefix=false
 mosip.signup.identifier.prefix=+855
 mosip.signup.supported-languages={'eng','khm'}
 

--- a/signup-service/src/test/java/io/mosip/signup/helper/NotificationHelperTest.java
+++ b/signup-service/src/test/java/io/mosip/signup/helper/NotificationHelperTest.java
@@ -57,28 +57,18 @@ public class NotificationHelperTest {
         String templateKey = "send-otp";
         String message = "Hello, {{name}}!";
 
-        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale))
-                .thenReturn(Base64.getEncoder().encodeToString(message.getBytes()));
+        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale)).thenReturn(Base64.getEncoder().encodeToString(message.getBytes()));
         Map<String, String> params = new HashMap<>();
         params.put("{{name}}", "John");
 
         RestResponseWrapper<NotificationResponse> responseWrapper = new RestResponseWrapper<>();
         ResponseEntity<RestResponseWrapper<NotificationResponse>> responseEntity = mock(ResponseEntity.class);
         when(responseEntity.getBody()).thenReturn(responseWrapper);
-        when(selfTokenRestTemplate.exchange(
-                eq(sendNotificationEndpoint),
-                eq(HttpMethod.POST),
-                any(HttpEntity.class),
-                any(ParameterizedTypeReference.class)))
-                .thenReturn(responseEntity);
+        when(selfTokenRestTemplate.exchange(eq(sendNotificationEndpoint), eq(HttpMethod.POST), any(HttpEntity.class), any(ParameterizedTypeReference.class))).thenReturn(responseEntity);
 
         notificationHelper.sendNotification("1234567890", locale, templateKey, params);
 
-        verify(selfTokenRestTemplate, times(1)).exchange(
-                eq(sendNotificationEndpoint),
-                eq(HttpMethod.POST),
-                any(HttpEntity.class),
-                any(ParameterizedTypeReference.class));
+        verify(selfTokenRestTemplate, times(1)).exchange(eq(sendNotificationEndpoint), eq(HttpMethod.POST), any(HttpEntity.class), any(ParameterizedTypeReference.class));
     }
 
     @Test(expected = SignUpException.class)
@@ -87,15 +77,9 @@ public class NotificationHelperTest {
         String templateKey = "send-otp";
         String message = "Hello, {{name}}!";
 
-        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale))
-                .thenReturn(Base64.getEncoder().encodeToString(message.getBytes()));
+        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale)).thenReturn(Base64.getEncoder().encodeToString(message.getBytes()));
 
-        when(selfTokenRestTemplate.exchange(
-                eq(sendNotificationEndpoint),
-                eq(HttpMethod.POST),
-                any(HttpEntity.class),
-                any(ParameterizedTypeReference.class)))
-                .thenThrow(new RestClientException("Error in RestTemplate"));
+        when(selfTokenRestTemplate.exchange(eq(sendNotificationEndpoint), eq(HttpMethod.POST), any(HttpEntity.class), any(ParameterizedTypeReference.class))).thenThrow(new RestClientException("Error in RestTemplate"));
 
         notificationHelper.sendNotification("1234567890", locale, templateKey, null);
     }
@@ -106,8 +90,7 @@ public class NotificationHelperTest {
         String templateKey = "send-otp";
         String message = "Hello, {{name}}!";
 
-        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + defaultLanguage))
-                .thenReturn(Base64.getEncoder().encodeToString(message.getBytes()));
+        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + defaultLanguage)).thenReturn(Base64.getEncoder().encodeToString(message.getBytes()));
 
         Map<String, String> params = new HashMap<>();
         params.put("{{name}}", "John");
@@ -115,20 +98,11 @@ public class NotificationHelperTest {
         RestResponseWrapper<NotificationResponse> responseWrapper = new RestResponseWrapper<>();
         ResponseEntity<RestResponseWrapper<NotificationResponse>> responseEntity = mock(ResponseEntity.class);
         when(responseEntity.getBody()).thenReturn(responseWrapper);
-        when(selfTokenRestTemplate.exchange(
-                eq(sendNotificationEndpoint),
-                eq(HttpMethod.POST),
-                any(HttpEntity.class),
-                any(ParameterizedTypeReference.class)))
-                .thenReturn(responseEntity);
+        when(selfTokenRestTemplate.exchange(eq(sendNotificationEndpoint), eq(HttpMethod.POST), any(HttpEntity.class), any(ParameterizedTypeReference.class))).thenReturn(responseEntity);
 
         notificationHelper.sendNotification("1234567890", locale, templateKey, params);
 
-        verify(selfTokenRestTemplate, times(1)).exchange(
-                eq(sendNotificationEndpoint),
-                eq(HttpMethod.POST),
-                any(HttpEntity.class),
-                any(ParameterizedTypeReference.class));
+        verify(selfTokenRestTemplate, times(1)).exchange(eq(sendNotificationEndpoint), eq(HttpMethod.POST), any(HttpEntity.class), any(ParameterizedTypeReference.class));
     }
 
     @Test
@@ -139,25 +113,18 @@ public class NotificationHelperTest {
         String locale = "eng";
         String message = "Hello";
 
-        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale))
-                .thenReturn(Base64.getEncoder().encodeToString(message.getBytes()));
+        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale)).thenReturn(Base64.getEncoder().encodeToString(message.getBytes()));
 
         RestResponseWrapper<NotificationResponse> responseWrapper = new RestResponseWrapper<>();
         ResponseEntity<RestResponseWrapper<NotificationResponse>> responseEntity = mock(ResponseEntity.class);
 
         when(responseEntity.getBody()).thenReturn(responseWrapper);
 
-        when(selfTokenRestTemplate.exchange(
-                eq(sendNotificationEndpoint),
-                eq(HttpMethod.POST),
-                any(HttpEntity.class),
-                any(ParameterizedTypeReference.class)))
-                .thenReturn(responseEntity);
+        when(selfTokenRestTemplate.exchange(eq(sendNotificationEndpoint), eq(HttpMethod.POST), any(HttpEntity.class), any(ParameterizedTypeReference.class))).thenReturn(responseEntity);
 
         spyNotificationHelper.sendNotificationAsync("1234567890", locale, templateKey, null);
 
-        verify(spyNotificationHelper, times(1))
-                .sendNotification("1234567890", locale, templateKey, null);
+        verify(spyNotificationHelper, times(1)).sendNotification("1234567890", locale, templateKey, null);
     }
 
     @Test
@@ -167,28 +134,17 @@ public class NotificationHelperTest {
         String locale = "eng";
         String templateKey = "send-otp";
 
-        when(environment.getProperty("mosip.signup.email-notification-template.subject." + templateKey + "." + locale))
-                .thenReturn("OTP Verification");
-        when(environment.getProperty("mosip.signup.email-notification-template.content." + templateKey + "." + locale))
-                .thenReturn("Use {challenge} to verify your account.");
+        when(environment.getProperty("mosip.signup.email-notification-template.subject." + templateKey + "." + locale)).thenReturn("OTP Verification");
+        when(environment.getProperty("mosip.signup.email-notification-template.content." + templateKey + "." + locale)).thenReturn("Use {challenge} to verify your account.");
 
         RestResponseWrapper<NotificationResponse> responseWrapper = new RestResponseWrapper<>();
         ResponseEntity<RestResponseWrapper<NotificationResponse>> responseEntity = mock(ResponseEntity.class);
         when(responseEntity.getBody()).thenReturn(responseWrapper);
-        when(selfTokenRestTemplate.exchange(
-                eq(sendNotificationEndpoint),
-                eq(HttpMethod.POST),
-                any(HttpEntity.class),
-                any(ParameterizedTypeReference.class)))
-                .thenReturn(responseEntity);
+        when(selfTokenRestTemplate.exchange(eq(sendNotificationEndpoint), eq(HttpMethod.POST), any(HttpEntity.class), any(ParameterizedTypeReference.class))).thenReturn(responseEntity);
 
         notificationHelper.sendNotification("user@example.com", locale, templateKey, null);
 
-        verify(selfTokenRestTemplate, times(1)).exchange(
-                eq(sendNotificationEndpoint),
-                eq(HttpMethod.POST),
-                any(HttpEntity.class),
-                any(ParameterizedTypeReference.class));
+        verify(selfTokenRestTemplate, times(1)).exchange(eq(sendNotificationEndpoint), eq(HttpMethod.POST), any(HttpEntity.class), any(ParameterizedTypeReference.class));
     }
 
     @Test(expected = SignUpException.class)
@@ -203,8 +159,7 @@ public class NotificationHelperTest {
         String locale = "eng";
         String templateKey = "send-otp";
 
-        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale))
-                .thenReturn(null);  // property not configured
+        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale)).thenReturn(null);  // property not configured
 
         notificationHelper.sendNotification("+85512345678", locale, templateKey, null);
     }
@@ -218,26 +173,16 @@ public class NotificationHelperTest {
         String templateKey = "send-otp";
         String message = "Use {challenge} to verify your account.";
 
-        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale))
-                .thenReturn(message);
+        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale)).thenReturn(message);
 
         RestResponseWrapper<NotificationResponse> responseWrapper = new RestResponseWrapper<>();
         ResponseEntity<RestResponseWrapper<NotificationResponse>> responseEntity = mock(ResponseEntity.class);
         when(responseEntity.getBody()).thenReturn(responseWrapper);
-        when(selfTokenRestTemplate.exchange(
-                eq(sendNotificationEndpoint),
-                eq(HttpMethod.POST),
-                any(HttpEntity.class),
-                any(ParameterizedTypeReference.class)))
-                .thenReturn(responseEntity);
+        when(selfTokenRestTemplate.exchange(eq(sendNotificationEndpoint), eq(HttpMethod.POST), any(HttpEntity.class), any(ParameterizedTypeReference.class))).thenReturn(responseEntity);
 
         // +855 prefix should be stripped → 12345678
         notificationHelper.sendNotification("+85512345678", locale, templateKey, null);
 
-        verify(selfTokenRestTemplate, times(1)).exchange(
-                eq(sendNotificationEndpoint),
-                eq(HttpMethod.POST),
-                any(HttpEntity.class),
-                any(ParameterizedTypeReference.class));
+        verify(selfTokenRestTemplate, times(1)).exchange(eq(sendNotificationEndpoint), eq(HttpMethod.POST), any(HttpEntity.class), any(ParameterizedTypeReference.class));
     }
 }

--- a/signup-service/src/test/java/io/mosip/signup/helper/NotificationHelperTest.java
+++ b/signup-service/src/test/java/io/mosip/signup/helper/NotificationHelperTest.java
@@ -52,12 +52,12 @@ public class NotificationHelperTest {
     }
 
     @Test
-    public void test_SendNotification_withValidInput_thenPass() {
+    public void sendNotification_withValidInput_thenPass() {
         String locale = "eng";
         String templateKey = "send-otp";
         String message = "Hello, {{name}}!";
 
-        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale)).thenReturn(Base64.getEncoder().encodeToString(message.getBytes()));
+        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale)).thenReturn(message);
         Map<String, String> params = new HashMap<>();
         params.put("{{name}}", "John");
 
@@ -72,12 +72,12 @@ public class NotificationHelperTest {
     }
 
     @Test(expected = SignUpException.class)
-    public void test_SendNotification_onRestException_thenFail() {
+    public void sendNotification_onRestException_thenFail() {
         String locale = "eng";
         String templateKey = "send-otp";
         String message = "Hello, {{name}}!";
 
-        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale)).thenReturn(Base64.getEncoder().encodeToString(message.getBytes()));
+        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale)).thenReturn(message);
 
         when(selfTokenRestTemplate.exchange(eq(sendNotificationEndpoint), eq(HttpMethod.POST), any(HttpEntity.class), any(ParameterizedTypeReference.class))).thenThrow(new RestClientException("Error in RestTemplate"));
 
@@ -85,12 +85,12 @@ public class NotificationHelperTest {
     }
 
     @Test
-    public void test_SendNotification_withNullLocale_thenPass() { //fallback to default language
+    public void sendNotification_withNullLocale_thenPass() { //fallback to default language
         String locale = null;
         String templateKey = "send-otp";
         String message = "Hello, {{name}}!";
 
-        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + defaultLanguage)).thenReturn(Base64.getEncoder().encodeToString(message.getBytes()));
+        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + defaultLanguage)).thenReturn(message);
 
         Map<String, String> params = new HashMap<>();
         params.put("{{name}}", "John");
@@ -106,14 +106,14 @@ public class NotificationHelperTest {
     }
 
     @Test
-    public void test_SendNotificationAsync() {
+    public void sendNotificationAsync() {
         NotificationHelper spyNotificationHelper = spy(notificationHelper);
 
         String templateKey = "send-otp";
         String locale = "eng";
         String message = "Hello";
 
-        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale)).thenReturn(Base64.getEncoder().encodeToString(message.getBytes()));
+        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale)).thenReturn(message);
 
         RestResponseWrapper<NotificationResponse> responseWrapper = new RestResponseWrapper<>();
         ResponseEntity<RestResponseWrapper<NotificationResponse>> responseEntity = mock(ResponseEntity.class);
@@ -128,7 +128,7 @@ public class NotificationHelperTest {
     }
 
     @Test
-    public void test_SendNotification_withEmailChannel_thenPass() {
+    public void sendNotification_withEmailChannel_thenPass() {
         ReflectionTestUtils.setField(notificationHelper, "defaultChannel", "email");
 
         String locale = "eng";
@@ -148,14 +148,14 @@ public class NotificationHelperTest {
     }
 
     @Test(expected = SignUpException.class)
-    public void test_SendNotification_withUnsupportedChannel_thenFail() {
+    public void sendNotification_withUnsupportedChannel_thenFail() {
         ReflectionTestUtils.setField(notificationHelper, "defaultChannel", "push");
 
         notificationHelper.sendNotification("user@example.com", "eng", "send-otp", null);
     }
 
     @Test(expected = SignUpException.class)
-    public void test_SendNotification_templateNotFound_thenFail() {
+    public void sendNotification_templateNotFound_thenFail() {
         String locale = "eng";
         String templateKey = "send-otp";
 
@@ -165,7 +165,7 @@ public class NotificationHelperTest {
     }
 
     @Test
-    public void test_SendNotification_withRemoveCountryCode_thenPass() {
+    public void sendNotification_withRemoveCountryCode_thenPass() {
         ReflectionTestUtils.setField(notificationHelper, "removeCountryCode", true);
         ReflectionTestUtils.setField(notificationHelper, "identifierPrefix", "+855");
 
@@ -181,6 +181,24 @@ public class NotificationHelperTest {
         when(selfTokenRestTemplate.exchange(eq(sendNotificationEndpoint), eq(HttpMethod.POST), any(HttpEntity.class), any(ParameterizedTypeReference.class))).thenReturn(responseEntity);
 
         // +855 prefix should be stripped → 12345678
+        notificationHelper.sendNotification("+85512345678", locale, templateKey, null);
+
+        verify(selfTokenRestTemplate, times(1)).exchange(eq(sendNotificationEndpoint), eq(HttpMethod.POST), any(HttpEntity.class), any(ParameterizedTypeReference.class));
+    }
+
+    @Test
+    public void sendNotification_withEncodedKhmTemplate_thenPass() {
+        String locale = "khm";
+        String templateKey = "send-otp";
+        String message = "Use {challenge} to verify your account.";
+
+        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale)).thenReturn(Base64.getEncoder().encodeToString(message.getBytes()));
+
+        RestResponseWrapper<NotificationResponse> responseWrapper = new RestResponseWrapper<>();
+        ResponseEntity<RestResponseWrapper<NotificationResponse>> responseEntity = mock(ResponseEntity.class);
+        when(responseEntity.getBody()).thenReturn(responseWrapper);
+        when(selfTokenRestTemplate.exchange(eq(sendNotificationEndpoint), eq(HttpMethod.POST), any(HttpEntity.class), any(ParameterizedTypeReference.class))).thenReturn(responseEntity);
+
         notificationHelper.sendNotification("+85512345678", locale, templateKey, null);
 
         verify(selfTokenRestTemplate, times(1)).exchange(eq(sendNotificationEndpoint), eq(HttpMethod.POST), any(HttpEntity.class), any(ParameterizedTypeReference.class));

--- a/signup-service/src/test/java/io/mosip/signup/helper/NotificationHelperTest.java
+++ b/signup-service/src/test/java/io/mosip/signup/helper/NotificationHelperTest.java
@@ -38,8 +38,8 @@ public class NotificationHelperTest {
     private Environment environment;
 
     private String sendNotificationEndpoint = "http://test.endpoint.com/send-notification";
-    private String defaultLanguage = "en";
-    private List<String> encodedLangCodes = List.of("es");
+    private String defaultLanguage = "eng";
+    private List<String> encodedLangCodes = List.of("khm");
 
     @Before
     public void setUp() {
@@ -47,15 +47,18 @@ public class NotificationHelperTest {
         ReflectionTestUtils.setField(notificationHelper, "defaultLanguage", defaultLanguage);
         ReflectionTestUtils.setField(notificationHelper, "encodedLangCodes", encodedLangCodes);
         ReflectionTestUtils.setField(notificationHelper, "identifierPrefix", "");
+        ReflectionTestUtils.setField(notificationHelper, "defaultChannel", "sms");
+        ReflectionTestUtils.setField(notificationHelper, "removeCountryCode", false);
     }
 
     @Test
-    public void testSendSMSNotification_withValidInput_thenPass() {
+    public void test_SendNotification_withValidInput_thenPass() {
         String locale = "eng";
-        String templateKey = "mosip.signup.sms-notification-template.send-otp";
+        String templateKey = "send-otp";
         String message = "Hello, {{name}}!";
 
-        when(environment.getProperty(templateKey + "." + locale)).thenReturn(Base64.getEncoder().encodeToString(message.getBytes()));
+        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale))
+                .thenReturn(Base64.getEncoder().encodeToString(message.getBytes()));
         Map<String, String> params = new HashMap<>();
         params.put("{{name}}", "John");
 
@@ -69,7 +72,7 @@ public class NotificationHelperTest {
                 any(ParameterizedTypeReference.class)))
                 .thenReturn(responseEntity);
 
-        notificationHelper.sendSMSNotification("1234567890", locale, templateKey, params);
+        notificationHelper.sendNotification("1234567890", locale, templateKey, params);
 
         verify(selfTokenRestTemplate, times(1)).exchange(
                 eq(sendNotificationEndpoint),
@@ -79,12 +82,13 @@ public class NotificationHelperTest {
     }
 
     @Test(expected = SignUpException.class)
-    public void testSendSMSNotification_onRestException_thenFail() {
+    public void test_SendNotification_onRestException_thenFail() {
         String locale = "eng";
-        String templateKey = "mosip.signup.sms-notification-template.send-otp";
+        String templateKey = "send-otp";
         String message = "Hello, {{name}}!";
 
-        when(environment.getProperty(templateKey + "." + locale)).thenReturn(message);
+        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale))
+                .thenReturn(Base64.getEncoder().encodeToString(message.getBytes()));
 
         when(selfTokenRestTemplate.exchange(
                 eq(sendNotificationEndpoint),
@@ -93,16 +97,17 @@ public class NotificationHelperTest {
                 any(ParameterizedTypeReference.class)))
                 .thenThrow(new RestClientException("Error in RestTemplate"));
 
-        notificationHelper.sendSMSNotification("1234567890", locale, templateKey, null);
+        notificationHelper.sendNotification("1234567890", locale, templateKey, null);
     }
 
     @Test
-    public void testSendSMSNotification_withNullLocale_thenPass() { //fallback to default language
+    public void test_SendNotification_withNullLocale_thenPass() { //fallback to default language
         String locale = null;
-        String templateKey = "mosip.signup.sms-notification-template.send-otp";
+        String templateKey = "send-otp";
         String message = "Hello, {{name}}!";
 
-        when(environment.getProperty(templateKey + "." + defaultLanguage)).thenReturn(Base64.getEncoder().encodeToString(message.getBytes()));
+        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + defaultLanguage))
+                .thenReturn(Base64.getEncoder().encodeToString(message.getBytes()));
 
         Map<String, String> params = new HashMap<>();
         params.put("{{name}}", "John");
@@ -117,7 +122,7 @@ public class NotificationHelperTest {
                 any(ParameterizedTypeReference.class)))
                 .thenReturn(responseEntity);
 
-        notificationHelper.sendSMSNotification("1234567890", locale, templateKey, params);
+        notificationHelper.sendNotification("1234567890", locale, templateKey, params);
 
         verify(selfTokenRestTemplate, times(1)).exchange(
                 eq(sendNotificationEndpoint),
@@ -127,9 +132,45 @@ public class NotificationHelperTest {
     }
 
     @Test
-    public void testSendSMSNotificationAsync() {
-        // Verify that the async method simply delegates to the sync method
+    public void test_SendNotificationAsync() {
         NotificationHelper spyNotificationHelper = spy(notificationHelper);
+
+        String templateKey = "send-otp";
+        String locale = "eng";
+        String message = "Hello";
+
+        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale))
+                .thenReturn(Base64.getEncoder().encodeToString(message.getBytes()));
+
+        RestResponseWrapper<NotificationResponse> responseWrapper = new RestResponseWrapper<>();
+        ResponseEntity<RestResponseWrapper<NotificationResponse>> responseEntity = mock(ResponseEntity.class);
+
+        when(responseEntity.getBody()).thenReturn(responseWrapper);
+
+        when(selfTokenRestTemplate.exchange(
+                eq(sendNotificationEndpoint),
+                eq(HttpMethod.POST),
+                any(HttpEntity.class),
+                any(ParameterizedTypeReference.class)))
+                .thenReturn(responseEntity);
+
+        spyNotificationHelper.sendNotificationAsync("1234567890", locale, templateKey, null);
+
+        verify(spyNotificationHelper, times(1))
+                .sendNotification("1234567890", locale, templateKey, null);
+    }
+
+    @Test
+    public void test_SendNotification_withEmailChannel_thenPass() {
+        ReflectionTestUtils.setField(notificationHelper, "defaultChannel", "email");
+
+        String locale = "eng";
+        String templateKey = "send-otp";
+
+        when(environment.getProperty("mosip.signup.email-notification-template.subject." + templateKey + "." + locale))
+                .thenReturn("OTP Verification");
+        when(environment.getProperty("mosip.signup.email-notification-template.content." + templateKey + "." + locale))
+                .thenReturn("Use {challenge} to verify your account.");
 
         RestResponseWrapper<NotificationResponse> responseWrapper = new RestResponseWrapper<>();
         ResponseEntity<RestResponseWrapper<NotificationResponse>> responseEntity = mock(ResponseEntity.class);
@@ -141,8 +182,62 @@ public class NotificationHelperTest {
                 any(ParameterizedTypeReference.class)))
                 .thenReturn(responseEntity);
 
-        spyNotificationHelper.sendSMSNotificationAsync("1234567890", "en", "sms.templateKey", null);
-        verify(spyNotificationHelper, times(1)).sendSMSNotification("1234567890", "en", "sms.templateKey", null);
+        notificationHelper.sendNotification("user@example.com", locale, templateKey, null);
+
+        verify(selfTokenRestTemplate, times(1)).exchange(
+                eq(sendNotificationEndpoint),
+                eq(HttpMethod.POST),
+                any(HttpEntity.class),
+                any(ParameterizedTypeReference.class));
+    }
+
+    @Test(expected = SignUpException.class)
+    public void test_SendNotification_withUnsupportedChannel_thenFail() {
+        ReflectionTestUtils.setField(notificationHelper, "defaultChannel", "push");
+
+        notificationHelper.sendNotification("user@example.com", "eng", "send-otp", null);
+    }
+
+    @Test(expected = SignUpException.class)
+    public void test_SendNotification_templateNotFound_thenFail() {
+        String locale = "eng";
+        String templateKey = "send-otp";
+
+        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale))
+                .thenReturn(null);  // property not configured
+
+        notificationHelper.sendNotification("+85512345678", locale, templateKey, null);
+    }
+
+    @Test
+    public void test_SendNotification_withRemoveCountryCode_thenPass() {
+        ReflectionTestUtils.setField(notificationHelper, "removeCountryCode", true);
+        ReflectionTestUtils.setField(notificationHelper, "identifierPrefix", "+855");
+
+        String locale = "eng";
+        String templateKey = "send-otp";
+        String message = "Use {challenge} to verify your account.";
+
+        when(environment.getProperty("mosip.signup.sms-notification-template." + templateKey + "." + locale))
+                .thenReturn(message);
+
+        RestResponseWrapper<NotificationResponse> responseWrapper = new RestResponseWrapper<>();
+        ResponseEntity<RestResponseWrapper<NotificationResponse>> responseEntity = mock(ResponseEntity.class);
+        when(responseEntity.getBody()).thenReturn(responseWrapper);
+        when(selfTokenRestTemplate.exchange(
+                eq(sendNotificationEndpoint),
+                eq(HttpMethod.POST),
+                any(HttpEntity.class),
+                any(ParameterizedTypeReference.class)))
+                .thenReturn(responseEntity);
+
+        // +855 prefix should be stripped → 12345678
+        notificationHelper.sendNotification("+85512345678", locale, templateKey, null);
+
+        verify(selfTokenRestTemplate, times(1)).exchange(
+                eq(sendNotificationEndpoint),
+                eq(HttpMethod.POST),
+                any(HttpEntity.class),
+                any(ParameterizedTypeReference.class));
     }
 }
-

--- a/signup-service/src/test/java/io/mosip/signup/services/RegistrationServiceTest.java
+++ b/signup-service/src/test/java/io/mosip/signup/services/RegistrationServiceTest.java
@@ -1113,7 +1113,7 @@ public class RegistrationServiceTest {
         when(challengeManagerService.generateChallenge(any())).thenReturn("1111");
         when(captchaHelper.validateCaptcha(
                 generateChallengeRequest.getCaptchaToken())).thenReturn(true);
-        doThrow(new SignUpException("otp_notification_failed")).when(notificationHelper).sendSMSNotification(any(), any(), any(), any());
+        doThrow(new SignUpException("otp_notification_failed")).when(notificationHelper).sendNotification(any(), any(), any(), any());
 
         try{
             registrationService.generateChallenge(generateChallengeRequest, "");


### PR DESCRIPTION
## Summary
Adds support for configurable notification channels (SMS/email) in the signup service.
Previously, only SMS notifications were supported with a hardcoded endpoint.
This change introduces a channel-based routing mechanism in NotificationHelper to
support both SMS and email notifications based on deployment configuration.

## Changes

### NotificationHelper
- Replaced `sendSMSNotification()` and `sendSMSNotificationAsync()` with generic
  `sendNotification()` and `sendNotificationAsync()` methods
- Added channel-based routing — email uses multipart/form-data, SMS uses JSON body
- Added `resolveTemplate()` helper to avoid code duplication between channels
- Renamed `removeIdentifierPrefix` field to `removeCountryCode` for clarity

### SignUpConstants
- Added `EMAIL_CHANNEL`, `SMS_CHANNEL`
- Added `SEND_OTP_TEMPLATE_KEY`, `REGISTRATION_TEMPLATE_KEY`, `FORGOT_PASSWORD_TEMPLATE_KEY`
- Added `SMS_TEMPLATE_PROPERTY_PREFIX`, `EMAIL_SUBJECT_PROPERTY_PREFIX`,
  `EMAIL_CONTENT_PROPERTY_PREFIX`

### application-default.properties
- Added `mosip.signup.send-notification.channel` — allowed values: `sms`, `email`
- Updated `mosip.signup.send-notification.endpoint` to dynamically resolve based on channel
- Renamed `mosip.signup.sms-notification-template.encoded-langcodes` to
  `mosip.signup.notification-template.encoded-langcodes`
- Renamed `mosip.signup.identifier.remove-prefix` to
  `mosip.signup.sms-notification.remove-country-code`
- Added email notification templates (subject + content) for `send-otp`,
  `registration`, `forgot-password` in `eng` and `khm`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-channel notifications: Email and SMS support with configurable default channel and endpoint.
  * Option to strip country code from phone numbers before sending SMS.
  * Email templates (subject + content) and multi-language templates with encoding detection and parameter substitution.
  * Asynchronous notification sending supported.

* **Tests**
  * Updated and added tests covering email flow, unsupported channel errors, template-not-found, country-code removal, encoding handling, and async delegation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->