### PR TITLE
Readme update - removed obsolete properties

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -43,7 +43,7 @@ For instructions on setting up eSignet Core, refer to the [eSignet Docker Compos
 2. Update below properties in [application-local.properties](../signup-service/src/main/resources/application-local.properties) with valid values:
 
    ```
-   mosip.internal.domain.url=https://api-internal.<env-name>.mosip.net
+   MOSIP_API_INTERNAL_HOST=https://api-internal.<env-name>.mosip.net
 
    keycloak.external.url=https://iam.<env-name>.mosip.net
 

--- a/signup-service/README.md
+++ b/signup-service/README.md
@@ -15,7 +15,7 @@ In this version, signup-service require below MOSIP kernel modules and its depen
 3. kernel authmanager
 4. kernel notifier
 
-**Note:** To run signup-service locally `mosip.internal.domain.url` property should be set with a valid base URL of any MOSIP(LTS) environment.
+**Note:** To run signup-service locally `MOSIP_API_INTERNAL_HOST` property should be set with a valid base URL of any MOSIP(LTS) environment.
 
 ### Signup service uses spring cache to store the transaction details.
 
@@ -84,11 +84,11 @@ The project requires JDK 21.
    
    3.4 Update below properties in [application-local.properties](src/main/resources/application-local.properties) to point to right MOSIP environment.
 
-      -> `mosip.internal.domain.url=https://api-internal.dev.mosip.net`
+      -> `MOSIP_API_INTERNAL_HOST=https://api-internal.env-name.mosip.net`   // add the right environment name in the URL
 
       -> `keycloak.external.url=https://iam.dev.mosip.net`
 
-      -> `mosip.signup.client.secret=actual-secret`
+      -> `mosip.signup.client.secret=actual-secret`  // add the actual client secret for the signup-service client registered in the Keycloak
 
    3.4 Go to [SignUpServiceApplication.java](src/main/java/io/mosip/signup/SignUpServiceApplication.java) and run from the main class.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated configuration docs to reflect the new API internal host property name and example URL format for local setups.
  * Clarified signup-service local-run instructions, including guidance to set the signup client secret to the actual Keycloak-registered value and how to insert the target environment name into example URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->