### PR TITLE
MOSIP-44784 - Removed the snapshot version for apitest commons library

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -69,7 +69,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.5.0-SNAPSHOT</version>
+			<version>1.5.0</version>
 		</dependency>
 	</dependencies>
 	<distributionManagement>


### PR DESCRIPTION
MOSIP-44784 - Removed the snapshot version for apitest commons library

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a core dependency from a development version to its stable released version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->