### PR TITLE
Update README with MOSIP_SIGNUP_IDENTIFIER_REGEX details

### DIFF
--- a/api-test/README.md
+++ b/api-test/README.md
@@ -74,6 +74,8 @@ These configurations need to be added as part of the eSignet service deployment 
 - **MOSIP_ESIGNET_CAPTCHA_REQUIRED**: (empty)
 - **uinGenerationProcessingDelayTimeInMilliSeconds**: 600000
 - **uinGenMaxLoopCount**: 20
+-  Automation scripts rely on **MOSIP_SIGNUP_IDENTIFIER_REGEX** for input validation during signup flows.
+Ensure that **MOSIP_SIGNUP_IDENTIFIER_REGEX** is explicitly defined in the configuration.
 
 These configurations need to be added as part of the Signup service deployment to support the API Test Rig:
 


### PR DESCRIPTION
Clarify the requirement for MOSIP_SIGNUP_IDENTIFIER_REGEX in the configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration documentation to clarify that the signup identifier regex must be explicitly defined in your configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->