### PR TITLE
[MOSIP-44769] Add domainConfig map to signup-service helm chart and s…

### DIFF
--- a/deploy/domain-values.yaml
+++ b/deploy/domain-values.yaml
@@ -1,0 +1,3 @@
+domainConfig:
+  MOSIP_ESIGNET_HOST: esignet.sandbox.xyz.net
+  MOSIP_SIGNUP_HOST: signup.sandbox.xyz.net

--- a/deploy/signup-service/install.sh
+++ b/deploy/signup-service/install.sh
@@ -75,7 +75,7 @@ function installing_signup() {
 
   echo Installing signup
   helm -n $NS install signup mosip/signup \
-    -f values.yaml --version $CHART_VERSION \
+    -f values.yaml -f ../domain-values.yaml --version $CHART_VERSION \
     --set image.repository=mosipid/signup-service --set image.tag=1.2.2 \
     $ENABLE_INSECURE $plugin_option \
     --set metrics.serviceMonitor.enabled=$servicemonitorflag --wait

--- a/deploy/signup-with-plugins/signup-with-mock-plugin/install.sh
+++ b/deploy/signup-with-plugins/signup-with-mock-plugin/install.sh
@@ -57,7 +57,7 @@ fi
 
 echo Installing signup-with-mock-plugin
 helm -n $NS install signup mosip/signup \
-  -f values.yaml --version $CHART_VERSION \
+  -f values.yaml -f ../../domain-values.yaml --version $CHART_VERSION \
   --set plugin_name_env=$PLUGIN_NAME \
   --set metrics.serviceMonitor.enabled=$servicemonitorflag \
   $ENABLE_INSECURE --wait

--- a/deploy/signup-with-plugins/signup-with-mosipid-plugin/install.sh
+++ b/deploy/signup-with-plugins/signup-with-mosipid-plugin/install.sh
@@ -57,7 +57,7 @@ fi
 
 echo Installing signup-with-mosipid-plugin
 helm -n $NS install signup mosip/signup \
-  -f values.yaml --version $CHART_VERSION \
+  -f values.yaml -f ../../domain-values.yaml --version $CHART_VERSION \
   --set plugin_name_env=$PLUGIN_NAME \
   --set metrics.serviceMonitor.enabled=$servicemonitorflag \
   $ENABLE_INSECURE --wait

--- a/helm/signup-service/Chart.yaml
+++ b/helm/signup-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: signup
 description: A Helm chart for DGTDept signup-service module
 type: application
-version: 1.7.1-develop
+version: 0.1.0-develop
 appVersion: ""
 dependencies:
   - name: common

--- a/helm/signup-service/Chart.yaml
+++ b/helm/signup-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: signup
 description: A Helm chart for DGTDept signup-service module
 type: application
-version: 0.0.1-develop
+version: 1.7.1-develop
 appVersion: ""
 dependencies:
   - name: common

--- a/helm/signup-service/templates/deployment.yaml
+++ b/helm/signup-service/templates/deployment.yaml
@@ -107,6 +107,10 @@ spec:
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+            {{- range $key, $val := .Values.domainConfig }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             {{- range .Values.extraEnvVarsCM }}

--- a/helm/signup-service/values.yaml
+++ b/helm/signup-service/values.yaml
@@ -241,17 +241,7 @@ updateStrategy:
 ##     value: "bar"
 ##
 
-extraEnvVars: |
-  - name: MOSIP_ESIGNET_HOST
-    valueFrom:
-      configMapKeyRef:
-        name: esignet-global
-        key: mosip-esignet-host
-  - name: MOSIP_SIGNUP_HOST
-    valueFrom:
-      configMapKeyRef:
-        name: esignet-global
-        key: mosip-signup-host
+extraEnvVars:
   - name: KEYCLOAK_EXTERNAL_URL
     valueFrom:
       configMapKeyRef:
@@ -515,3 +505,5 @@ volumes:
       path: /home/mosip/keys
 pluginNameEnv: esignet-mock-plugin.jar
 pluginUrlEnv:
+
+domainConfig: {}

--- a/helm/signup-service/values.yaml
+++ b/helm/signup-service/values.yaml
@@ -332,9 +332,8 @@ initContainers:
     env:
       - name: ENABLE_INSECURE
         value: "true"
-    envFrom:
-      - configMapRef:
-          name: global
+      - name: mosip-api-internal-host
+        value: '{{ index .Values.domainConfig "MOSIP_API_INTERNAL_HOST" | default "" }}'
     image: docker.io/openjdk:21-jre
     imagePullPolicy: Always
     name: cacerts

--- a/helm/signup-ui/Chart.yaml
+++ b/helm/signup-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: signup-ui
 description: A Helm chart for DGTDept SIGNUP UI module
 type: application
-version: 0.0.1-develop
+version: 1.7.1-develop
 appVersion: ""
 dependencies:
   - name: common

--- a/helm/signup-ui/Chart.yaml
+++ b/helm/signup-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: signup-ui
 description: A Helm chart for DGTDept SIGNUP UI module
 type: application
-version: 1.7.1-develop
+version: 0.1.0-develop
 appVersion: ""
 dependencies:
   - name: common


### PR DESCRIPTION
…implify deploy scripts

- Add domainConfig map to values.yaml replacing MOSIP_ESIGNET_HOST and MOSIP_SIGNUP_HOST extraEnvVar entries
- Add range loop in deployment.yaml to render domainConfig as env vars
- Remove domain host prompts from deploy scripts; use -f domain-values.yaml instead
- Add deploy/domain-values.yaml with esignet and signup host placeholders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart version to 1.7.1-develop.
  * Refactored configuration management to support customizable domain settings for service endpoints.
  * Updated deployment installation scripts to utilize new configuration structure for improved flexibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/esignet-signup/pull/916)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->