### PR TITLE
#1729 | Added complete docker-compose.yml to run the full signup setup

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -10,6 +10,59 @@ This is the docker-compose setup to run eSignet Signup service with mock identit
 4. Git bash
 5. Postman
 
+## Bring up the complete signup setup for a demo
+
+The [docker-compose.yml](docker-compose.yml) file brings up the complete signup setup — `signup-service` and `signup-ui` along with all the dependent services. With this setup, the signup service need not be run from the IDE.
+
+### Step 1: Generate the signup OIDC keystore
+
+1. Open a Git bash terminal in the [postman-collection](../postman-collection) folder and run:
+
+   ```bash
+   ./create-signup-oidc-keystore.sh
+   ```
+
+   This generates `oidckeystore.p12` and `public_key.jwk` in the repository root. The keystore is mounted into the `signup-service` container by `docker-compose.yml`, and `public_key.jwk` is needed while onboarding the signup OIDC client in [Step 4](#step-4-onboard-the-signup-oidc-client).
+
+### Step 2: Configure environment-specific values
+
+Update the below environment variables of the `signup-service` in `docker-compose.yml` with valid values. They are required for OTP generation and notifications:
+
+   ```properties
+   MOSIP_API_INTERNAL_HOST=https://api-internal.<env-name>.mosip.net
+   KEYCLOAK_EXTERNAL_URL=https://iam.<env-name>.mosip.net
+   MOSIP_SIGNUP_CLIENT_SECRET=<secret-from-env>
+   ```
+
+   > **Note:** `MOSIP_ESIGNET_SIGNUP_ID_TOKEN_AUDIENCE` is already set on the `esignet` service to `mosip-signup-oauth-client`, which is the client ID created by the signup Postman collection in [Step 4](#step-4-onboard-the-signup-oidc-client). If you onboard the signup OIDC client with a different client ID, update this variable accordingly.
+
+### Step 3: Start the services
+
+Open a terminal in the current directory and run:
+
+   ```bash
+   docker compose up
+   ```
+
+Wait until all the services are up:
+
+| Service | URL |
+|---|---|
+| signup UI | [http://localhost:3001](http://localhost:3001) |
+| signup service Swagger | [http://localhost:8089/v1/signup/swagger-ui.html](http://localhost:8089/v1/signup/swagger-ui.html) |
+| eSignet UI | [http://localhost:3000](http://localhost:3000) |
+| eSignet service Swagger | [http://localhost:8088/v1/esignet/swagger-ui.html](http://localhost:8088/v1/esignet/swagger-ui.html) |
+
+### Step 4: Onboard the signup OIDC client
+
+1. Import the files located in the [postman-collection](../postman-collection) folder into Postman and follow the [Postman README](../postman-collection/README.md) to create the signup OIDC client. Use the `public_key.jwk` generated in [Step 1](#step-1-generate-the-signup-oidc-keystore) as the client public key.
+
+2. To create an eSignet client and a mock identity, refer to the [eSignet Docker Compose documentation](https://github.com/mosip/esignet/blob/master/docker-compose/README.md#how-to-bring-up-the-complete-esignet-setup-for-a-demo).
+
+### Step 5: Access the signup UI
+
+Open [http://localhost:3001](http://localhost:3001) in the browser and walk through the signup flow.
+
 ## Run signup service in local with all its dependencies
 
 ### Step 1: Configure Dependent Services

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,0 +1,151 @@
+## Brings up the complete eSignet Signup setup for a demo: signup-service and signup-ui
+## along with all their dependent services. This is not for production use.
+## Refer to README.md in this directory for the pre-requisite steps (OIDC keystore generation,
+## client onboarding) before running `docker compose up`.
+
+services:
+
+  database:
+    image: 'postgres:bookworm'
+    ports:
+      - 5455:5432
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    volumes:
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+
+  mock-identity-system:
+    image: 'mosipdev/mock-identity-system:develop'
+    user: root
+    ports:
+      - 8082:8082
+    environment:
+      - container_user=mosip
+      - active_profile_env=default,local
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://database:5432/mosip_mockidentitysystem?currentSchema=mockidentitysystem
+      - SPRING_DATASOURCE_USERNAME=postgres
+      - SPRING_DATASOURCE_PASSWORD=postgres
+      - MOSIP_MOCK_IDA_KYC_TRANSACTION_TIMEOUT_SECS=1200
+      - MOSIP_MOCK_IDA_IDENTITY_SCHEMA_URL=classpath:/mock-identity-signup-schema.json
+      - MOSIP_ESIGNET_HOST=localhost:8088
+    depends_on:
+      - database
+
+  redis:
+    image: redis:6.0
+    container_name: redis-server
+    ports:
+      - "6379:6379"
+    restart: always
+
+  zookeeper:
+    image: wurstmeister/zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: wurstmeister/kafka
+    ports:
+      - "9092:9092"
+      - "9093:9093"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://kafka:9092,OUTSIDE://localhost:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_LISTENERS: INSIDE://0.0.0.0:9092,OUTSIDE://0.0.0.0:9093
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+
+
+  esignet:
+    image: 'mosipdev/esignet-with-plugins:develop'
+    user: root
+    ports:
+      - 8088:8088
+    environment:
+      - container_user=mosip
+      - active_profile_env=default,local
+      - plugin_name_env=esignet-mock-plugin.jar
+      - KAFKA_ENABLED=false
+      - SPRING_CACHE_TYPE=redis
+      - SPRING_DATA_REDIS_HOST=redis
+      - SPRING_DATA_REDIS_PASSWORD=
+      - MOSIP_ESIGNET_DATABASE_URL=jdbc:postgresql://database:5432/mosip_esignet?currentSchema=esignet
+      - MOSIP_ESIGNET_DATABASE_USERNAME=postgres
+      - MOSIP_ESIGNET_DATABASE_PASSWORD=postgres
+      - SPRING_AUTOCONFIGURE_EXCLUDE=org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
+      - MOSIP_ESIGNET_MOCK_DOMAIN_URL=http://mock-identity-system:8082
+      - MOSIP_ESIGNET_INTEGRATION_KEY_BINDER=MockKeyBindingWrapperService
+      ## Must match the client ID of the signup OIDC client onboarded in eSignet
+      ## (the signup Postman collection creates it as 'mosip-signup-oauth-client')
+      - MOSIP_ESIGNET_SIGNUP_ID_TOKEN_AUDIENCE=mosip-signup-oauth-client
+    depends_on:
+      - database
+      - redis
+      - mock-identity-system
+
+  esignet-ui:
+    image: 'mosipdev/oidc-ui:develop'
+    user: root
+    ports:
+      - 3000:3000
+    environment:
+      - container_user=mosip
+      - DEFAULT_WELLKNOWN=%5B%7B%22name%22%3A%22OpenID%20Configuration%22%2C%22value%22%3A%22%2F.well-known%2Fopenid-configuration%22%7D%2C%7B%22name%22%3A%22Jwks%20Json%22%2C%22value%22%3A%22%2F.well-known%2Fjwks.json%22%7D%2C%7B%22name%22%3A%22Authorization%20Server%22%2C%22value%22%3A%22%2F.well-known%2Foauth-authorization-server%22%7D%5D
+      - SIGN_IN_WITH_ESIGNET_PLUGIN_URL=https://raw.githubusercontent.com/mosip/artifactory-ref-impl/master/artifacts/src/mosip-plugins/sign-in-with-esignet/sign-in-with-esignet.zip
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - esignet
+
+  signup-service:
+    image: 'mosipdev/signup-with-plugins:develop'
+    user: root
+    ports:
+      - 8089:8089
+    environment:
+      - container_user=mosip
+      - active_profile_env=default,local
+      - plugin_name_env=esignet-mock-plugin.jar
+      - SPRING_DATA_REDIS_HOST=redis
+      - SPRING_DATA_REDIS_PORT=6379
+      - SPRING_DATA_REDIS_PASSWORD=
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      ## browser facing URLs: signup-ui is published on host port 3001 and esignet-ui on 3000
+      - MOSIP_SIGNUP_DOMAIN_URL=http://localhost:3001
+      - MOSIP_ESIGNET_DOMAIN_URL=http://localhost:3000
+      - MOSIP_ESIGNET_MOCK_DOMAIN_URL=http://mock-identity-system:8082
+      ## server to server calls to eSignet go over the compose network
+      - MOSIP_SIGNUP_OAUTH_TOKEN_URI=http://esignet:8088/v1/esignet/oauth/v2/token
+      - MOSIP_SIGNUP_OAUTH_USERINFO_URI=http://esignet:8088/v1/esignet/oidc/userinfo
+      ## no zipkin server in this setup, disable tracing to avoid log noise
+      - MANAGEMENT_TRACING_ENABLED=false
+      ## Replace the below 3 values with valid values from your MOSIP environment.
+      ## They are required for OTP generation and notifications (refer README.md).
+      - MOSIP_API_INTERNAL_HOST=https://api-internal.<env-name>.mosip.net
+      - KEYCLOAK_EXTERNAL_URL=https://iam.<env-name>.mosip.net
+      - MOSIP_SIGNUP_CLIENT_SECRET=<secret-from-env>
+    volumes:
+      ## Run postman-collection/create-signup-oidc-keystore.sh to generate
+      ## oidckeystore.p12 in the repository root before `docker compose up`
+      - ../oidckeystore.p12:/home/mosip/oidckeystore.p12
+    depends_on:
+      - database
+      - redis
+      - kafka
+      - esignet
+      - mock-identity-system
+
+  signup-ui:
+    image: 'mosipdev/signup-ui:develop'
+    user: root
+    ports:
+      ## host port 3001 since esignet-ui already uses 3000
+      - 3001:3000
+    environment:
+      - container_user=mosip
+    volumes:
+      - ./signup-ui-nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - signup-service

--- a/docker-compose/signup-ui-nginx.conf
+++ b/docker-compose/signup-ui-nginx.conf
@@ -1,0 +1,41 @@
+worker_processes  1;
+
+events {
+  worker_connections  1024;
+}
+
+http {
+  access_log /var/log/nginx/access.log;
+  error_log /var/log/nginx/error.log;
+  server {
+    listen 3000;
+    server_name  localhost;
+    server_tokens off;
+
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+    include /etc/nginx/mime.types;
+
+    gzip on;
+    gzip_min_length 1000;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+    location /v1/signup {
+      proxy_pass         http://signup-service:8089/v1/signup;
+      proxy_redirect     off;
+      proxy_set_header   Host $host;
+      proxy_set_header   X-Real-IP $remote_addr;
+      proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header   X-Forwarded-Host $server_name;
+      proxy_set_header   X-XSS-Protection "1; mode=block";
+      add_header         Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+      add_header         X-Frame-Options "DENY" always;
+
+    }
+
+    location / {
+      try_files $uri $uri/ /index.html;
+    }
+  }
+}


### PR DESCRIPTION
fix#1729

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a complete local demo environment using Docker Compose for an end-to-end eSignet and signup flow, including required backend services, UI components, and exposed host ports.

* **Documentation**
  * Updated the setup guide with step-by-step instructions to start the demo, generate the signup OIDC keystore, configure signup-service settings, onboard the OIDC client in Postman, and open the signup UI in a browser.

* **Configuration**
  * Added Nginx configuration to serve the signup SPA with proper routing fallback and to proxy `/v1/signup` to the signup service with appropriate headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->