### PR TITLE
[mosip/mosip-infra#1890] Added domainConfig support in helm charts

### DIFF
--- a/helm/signup-service/templates/deployment.yaml
+++ b/helm/signup-service/templates/deployment.yaml
@@ -107,6 +107,10 @@ spec:
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+            {{- range $key, $val := .Values.domainConfig }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             {{- range .Values.extraEnvVarsCM }}

--- a/helm/signup-service/values.yaml
+++ b/helm/signup-service/values.yaml
@@ -516,4 +516,5 @@ volumes:
 pluginNameEnv: esignet-mock-plugin.jar
 pluginUrlEnv:
 
+# domainConfig entries are injected as container env vars; values must be scalar/string (maps/lists will not render correctly)
 domainConfig: {}

--- a/helm/signup-service/values.yaml
+++ b/helm/signup-service/values.yaml
@@ -515,3 +515,5 @@ volumes:
       path: /home/mosip/keys
 pluginNameEnv: esignet-mock-plugin.jar
 pluginUrlEnv:
+
+domainConfig: {}


### PR DESCRIPTION
## Summary
Cherry-pick of #935 from `develop` onto `release-1.4.x`: adds `domainConfig` support in the signup-service helm chart (deployment.yaml and values.yaml), replacing `esignet-global` with a generic domainConfig values mechanism.

Original commit: mosip/esignet-signup@b27e54e0327d059e4b3a68d39d08363a6a401491

## Test plan
- [ ] Verify helm template renders domainConfig env vars correctly
- [ ] Verify no regression for deployments without domainConfig set