### PR TITLE
Add UI tests for error-handler, transaction-timeout and unified-login flows

### DIFF
--- a/ui-test/dependency-reduced-pom.xml
+++ b/ui-test/dependency-reduced-pom.xml
@@ -3,10 +3,10 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.mosip.signup</groupId>
   <artifactId>uitest-signup</artifactId>
-  <name>uitest-esignet</name>
+  <name>ui-test-esignet</name>
   <version>1.4.1-SNAPSHOT</version>
   <description>UI test automation project for MOSIP eSignet</description>
-  <url>https://github.com/mosip/esignet</url>
+  <url>https://github.com/mosip/uitest-esignet</url>
   <developers>
     <developer>
       <name>Mosip</name>

--- a/ui-test/dependency-reduced-pom.xml
+++ b/ui-test/dependency-reduced-pom.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>io.mosip.esignet</groupId>
-  <artifactId>uitest-esignet</artifactId>
-  <name>ui-test-esignet</name>
-  <version>1.6.1-SNAPSHOT</version>
+  <groupId>io.mosip.signup</groupId>
+  <artifactId>uitest-signup</artifactId>
+  <name>uitest-esignet</name>
+  <version>1.4.1-SNAPSHOT</version>
   <description>UI test automation project for MOSIP eSignet</description>
-  <url>https://github.com/mosip/uitest-esignet</url>
+  <url>https://github.com/mosip/esignet</url>
   <developers>
     <developer>
       <name>Mosip</name>
@@ -143,6 +143,14 @@
       </plugin>
     </plugins>
   </build>
+  <repositories>
+    <repository>
+      <snapshots />
+      <id>ossrh-central</id>
+      <name>MavenCentralRepository</name>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+    </repository>
+  </repositories>
   <dependencies>
     <dependency>
       <groupId>org.projectlombok</groupId>
@@ -163,7 +171,7 @@
   <properties>
     <lombok.version>1.18.30</lombok.version>
     <maven.compiler.target>21</maven.compiler.target>
-    <selenium.version>4.14.1</selenium.version>
+    <selenium.version>4.45.0</selenium.version>
     <cucumber.version>7.21.1</cucumber.version>
     <maven.compiler.source>21</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/ui-test/dependency-reduced-pom.xml
+++ b/ui-test/dependency-reduced-pom.xml
@@ -3,10 +3,10 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.mosip.signup</groupId>
   <artifactId>uitest-signup</artifactId>
-  <name>ui-test-esignet</name>
+  <name>uitest-signup</name>
   <version>1.4.1-SNAPSHOT</version>
   <description>UI test automation project for MOSIP eSignet</description>
-  <url>https://github.com/mosip/uitest-esignet</url>
+  <url>https://github.com/mosip/esignet-signup</url>
   <developers>
     <developer>
       <name>Mosip</name>

--- a/ui-test/dependency-reduced-pom.xml
+++ b/ui-test/dependency-reduced-pom.xml
@@ -145,6 +145,9 @@
   </build>
   <repositories>
     <repository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
       <snapshots />
       <id>ossrh-central</id>
       <name>MavenCentralRepository</name>

--- a/ui-test/pom.xml
+++ b/ui-test/pom.xml
@@ -51,7 +51,7 @@
 		<maven.compiler.target>21</maven.compiler.target>
 		<cucumber.version>7.21.1</cucumber.version>
 		<maven.compiler.source>21</maven.compiler.source>
-		<selenium.version>4.14.1</selenium.version>
+		<selenium.version>4.45.0</selenium.version>
 		<surefire.plugin.version>3.5.3</surefire.plugin.version>
 		<maven.shade.plugin.version>3.2.4</maven.shade.plugin.version>
 		<lombok.version>1.18.30</lombok.version>
@@ -65,8 +65,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-devtools-v134</artifactId>
-			<version>4.31.0</version>
+			<artifactId>selenium-devtools-v149</artifactId>
+			<version>${selenium.version}</version>
 		</dependency>
 
 		<dependency>

--- a/ui-test/pom.xml
+++ b/ui-test/pom.xml
@@ -24,6 +24,9 @@
 			<name>MavenCentralRepository</name>
 			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
 			<layout>default</layout>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/ui-test/src/main/java/base/BasePage.java
+++ b/ui-test/src/main/java/base/BasePage.java
@@ -11,12 +11,15 @@ import java.util.List;
 
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
+import org.openqa.selenium.ElementClickInterceptedException;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoAlertPresentException;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.OutputType;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
@@ -85,9 +88,23 @@ public class BasePage {
 		WaitUtil.waitForVisibility(driver, element);
 	}
 
+	public void waitForElementClickable(WebElement element) {
+		WaitUtil.waitForClickability(driver, element);
+	}
+
+	/**
+	 * Clicks the element once it is clickable - visible <em>and</em> enabled.
+	 *
+	 * <p>Waiting on visibility alone is not enough on these screens: buttons are
+	 * commonly rendered disabled until form validation passes, or are still
+	 * animating in, so a click fired the instant they become visible lands on a
+	 * still-disabled control and is silently dropped (or throws
+	 * ElementClickInterceptedException). Waiting for clickability here means page
+	 * objects do not each have to re-add that wait before every click.
+	 */
 	public void clickOnElement(WebElement element, String stepDesc) {
 		try {
-			waitForElementVisible(element);
+			waitForElementClickable(element);
 
 			element.click();
 			logStep(stepDesc, element);
@@ -358,6 +375,82 @@ public class BasePage {
 		}
 	}
 	
+	// ---- Shared NavBar language dropdown --------------------------------------
+
+	/** Attempts a transiently-flaky interaction gets before it is treated as failed. */
+	private static final int TRANSIENT_RETRY_ATTEMPTS = 3;
+
+	private static final By LANGUAGE_TRIGGER = By.id("language-select-button");
+
+	/**
+	 * Runs an interaction that is known to fail transiently, retrying it before
+	 * giving up.
+	 *
+	 * <p>Retried on the three symptoms a half-rendered React control produces: a
+	 * wait that expires ({@link TimeoutException}), an element replaced by a
+	 * re-render ({@link StaleElementReferenceException}) and a click landing on
+	 * something still animating over the target
+	 * ({@link ElementClickInterceptedException}). Anything else is a real failure
+	 * and propagates immediately.
+	 *
+	 * @param description what is being attempted, used in the failure message
+	 * @param action      the interaction; must be safe to run more than once
+	 */
+	public void retryOnTransientFailure(String description, Runnable action) {
+		RuntimeException lastError = null;
+		for (int attempt = 1; attempt <= TRANSIENT_RETRY_ATTEMPTS; attempt++) {
+			try {
+				action.run();
+				return;
+			} catch (TimeoutException | StaleElementReferenceException | ElementClickInterceptedException e) {
+				lastError = e;
+				LOGGER.warn("Attempt {}/{} to {} failed with {}, retrying", attempt, TRANSIENT_RETRY_ATTEMPTS,
+						description, e.getClass().getSimpleName());
+			}
+		}
+		throw new TimeoutException(
+				"Failed to " + description + " after " + TRANSIENT_RETRY_ATTEMPTS + " attempts", lastError);
+	}
+
+	/**
+	 * Budget for a single attempt inside {@link #retryOnTransientFailure}. The
+	 * configured timeout is split across the attempts so that retrying bounds the
+	 * total wait at roughly explicitWaitTimeout per element, instead of multiplying
+	 * it by the attempt count.
+	 *
+	 * <p>Rounded up so the attempts together still spend the whole configured
+	 * budget: rounding down would give 3s x 3 = 9s for a 10s timeout, and 1s x 3 =
+	 * 3s for a 5s one, waiting less in total than the configuration asks for. The
+	 * one-second floor keeps a very small configured timeout usable.
+	 */
+	private static Duration perAttemptWait() {
+		int timeout = EsignetConfigManager.getTimeout();
+		return Duration
+				.ofSeconds(Math.max(1, (timeout + TRANSIENT_RETRY_ATTEMPTS - 1) / TRANSIENT_RETRY_ATTEMPTS));
+	}
+
+	/**
+	 * Switches the app language through the NavBar dropdown shared by every screen.
+	 *
+	 * <p>The dropdown is a headless-UI menu whose trigger only becomes interactive
+	 * once React has attached its handler, so a click fired the instant the button
+	 * is merely visible can be a no-op that leaves the menu closed and the option
+	 * never appearing. Selecting a language then re-renders the page (i18n change),
+	 * which can stale a menu still mid-animation. Opening and selecting is therefore
+	 * retried as a unit. This lives here rather than in a page object because the
+	 * NavBar - and this flakiness - is common to all of them.
+	 *
+	 * @param twoLetterLangKey two letter language key, e.g. "en" or "km"
+	 */
+	public void switchLanguage(String twoLetterLangKey) {
+		By option = By.id(twoLetterLangKey + "_language");
+		retryOnTransientFailure("switch language to '" + twoLetterLangKey + "'", () -> {
+			WaitUtil.waitForClickability(driver, LANGUAGE_TRIGGER, perAttemptWait()).click();
+			WaitUtil.waitForClickability(driver, option, perAttemptWait()).click();
+		});
+		logStep("Switched language to '" + twoLetterLangKey + "'", option);
+	}
+
 	public static void selectCurrentRunLanguage(WebDriver driver) {
 	String languagePassed = MultiLanguageUtil.getDisplayName(BaseTestUtil.getThreadLocalLanguage());
 

--- a/ui-test/src/main/java/base/BasePage.java
+++ b/ui-test/src/main/java/base/BasePage.java
@@ -440,15 +440,34 @@ public class BasePage {
 	 * retried as a unit. This lives here rather than in a page object because the
 	 * NavBar - and this flakiness - is common to all of them.
 	 *
+	 * <p>The trigger toggles, so a retry only opens the menu when the option is not
+	 * already showing. Clicking it unconditionally would close a menu that the
+	 * previous attempt had successfully opened, spending that attempt waiting for an
+	 * option that can no longer appear.
+	 *
 	 * @param twoLetterLangKey two letter language key, e.g. "en" or "km"
 	 */
 	public void switchLanguage(String twoLetterLangKey) {
 		By option = By.id(twoLetterLangKey + "_language");
 		retryOnTransientFailure("switch language to '" + twoLetterLangKey + "'", () -> {
-			WaitUtil.waitForClickability(driver, LANGUAGE_TRIGGER, perAttemptWait()).click();
+			if (!isElementDisplayed(option)) {
+				WaitUtil.waitForClickability(driver, LANGUAGE_TRIGGER, perAttemptWait()).click();
+			}
 			WaitUtil.waitForClickability(driver, option, perAttemptWait()).click();
 		});
 		logStep("Switched language to '" + twoLetterLangKey + "'", option);
+	}
+
+	/**
+	 * Whether an element is present in the DOM and displayed, without waiting.
+	 *
+	 * <p>Locator counterpart to {@link #isElementDisplayed(WebElement)}, for asking
+	 * about something that may legitimately be absent: {@code findElements} yields
+	 * an empty list rather than throwing.
+	 */
+	private boolean isElementDisplayed(By locator) {
+		List<WebElement> matches = driver.findElements(locator);
+		return !matches.isEmpty() && isElementDisplayed(matches.get(0));
 	}
 
 	public static void selectCurrentRunLanguage(WebDriver driver) {

--- a/ui-test/src/main/java/base/BasePage.java
+++ b/ui-test/src/main/java/base/BasePage.java
@@ -92,16 +92,7 @@ public class BasePage {
 		WaitUtil.waitForClickability(driver, element);
 	}
 
-	/**
-	 * Clicks the element once it is clickable - visible <em>and</em> enabled.
-	 *
-	 * <p>Waiting on visibility alone is not enough on these screens: buttons are
-	 * commonly rendered disabled until form validation passes, or are still
-	 * animating in, so a click fired the instant they become visible lands on a
-	 * still-disabled control and is silently dropped (or throws
-	 * ElementClickInterceptedException). Waiting for clickability here means page
-	 * objects do not each have to re-add that wait before every click.
-	 */
+	// Clickability, not just visibility: buttons here stay disabled until validation passes
 	public void clickOnElement(WebElement element, String stepDesc) {
 		try {
 			waitForElementClickable(element);
@@ -377,25 +368,11 @@ public class BasePage {
 	
 	// ---- Shared NavBar language dropdown --------------------------------------
 
-	/** Attempts a transiently-flaky interaction gets before it is treated as failed. */
 	private static final int TRANSIENT_RETRY_ATTEMPTS = 3;
 
 	private static final By LANGUAGE_TRIGGER = By.id("language-select-button");
 
-	/**
-	 * Runs an interaction that is known to fail transiently, retrying it before
-	 * giving up.
-	 *
-	 * <p>Retried on the three symptoms a half-rendered React control produces: a
-	 * wait that expires ({@link TimeoutException}), an element replaced by a
-	 * re-render ({@link StaleElementReferenceException}) and a click landing on
-	 * something still animating over the target
-	 * ({@link ElementClickInterceptedException}). Anything else is a real failure
-	 * and propagates immediately.
-	 *
-	 * @param description what is being attempted, used in the failure message
-	 * @param action      the interaction; must be safe to run more than once
-	 */
+	// Retries only the symptoms of a half-rendered React control; the action must be safe to repeat
 	public void retryOnTransientFailure(String description, Runnable action) {
 		RuntimeException lastError = null;
 		for (int attempt = 1; attempt <= TRANSIENT_RETRY_ATTEMPTS; attempt++) {
@@ -412,44 +389,18 @@ public class BasePage {
 				"Failed to " + description + " after " + TRANSIENT_RETRY_ATTEMPTS + " attempts", lastError);
 	}
 
-	/**
-	 * Budget for a single attempt inside {@link #retryOnTransientFailure}. The
-	 * configured timeout is split across the attempts so that retrying bounds the
-	 * total wait at roughly explicitWaitTimeout per element, instead of multiplying
-	 * it by the attempt count.
-	 *
-	 * <p>Rounded up so the attempts together still spend the whole configured
-	 * budget: rounding down would give 3s x 3 = 9s for a 10s timeout, and 1s x 3 =
-	 * 3s for a 5s one, waiting less in total than the configuration asks for. The
-	 * one-second floor keeps a very small configured timeout usable.
-	 */
+	// Splits the configured timeout across the attempts, rounded up, so retrying does not multiply the wait
 	private static Duration perAttemptWait() {
 		int timeout = EsignetConfigManager.getTimeout();
 		return Duration
 				.ofSeconds(Math.max(1, (timeout + TRANSIENT_RETRY_ATTEMPTS - 1) / TRANSIENT_RETRY_ATTEMPTS));
 	}
 
-	/**
-	 * Switches the app language through the NavBar dropdown shared by every screen.
-	 *
-	 * <p>The dropdown is a headless-UI menu whose trigger only becomes interactive
-	 * once React has attached its handler, so a click fired the instant the button
-	 * is merely visible can be a no-op that leaves the menu closed and the option
-	 * never appearing. Selecting a language then re-renders the page (i18n change),
-	 * which can stale a menu still mid-animation. Opening and selecting is therefore
-	 * retried as a unit. This lives here rather than in a page object because the
-	 * NavBar - and this flakiness - is common to all of them.
-	 *
-	 * <p>The trigger toggles, so a retry only opens the menu when the option is not
-	 * already showing. Clicking it unconditionally would close a menu that the
-	 * previous attempt had successfully opened, spending that attempt waiting for an
-	 * option that can no longer appear.
-	 *
-	 * @param twoLetterLangKey two letter language key, e.g. "en" or "km"
-	 */
+	// Opening and selecting is retried as a unit: the i18n re-render can stale a menu mid-animation
 	public void switchLanguage(String twoLetterLangKey) {
 		By option = By.id(twoLetterLangKey + "_language");
 		retryOnTransientFailure("switch language to '" + twoLetterLangKey + "'", () -> {
+			// The trigger toggles, so a retry must not close a menu already opened
 			if (!isElementDisplayed(option)) {
 				WaitUtil.waitForClickability(driver, LANGUAGE_TRIGGER, perAttemptWait()).click();
 			}
@@ -458,13 +409,7 @@ public class BasePage {
 		logStep("Switched language to '" + twoLetterLangKey + "'", option);
 	}
 
-	/**
-	 * Whether an element is present in the DOM and displayed, without waiting.
-	 *
-	 * <p>Locator counterpart to {@link #isElementDisplayed(WebElement)}, for asking
-	 * about something that may legitimately be absent: {@code findElements} yields
-	 * an empty list rather than throwing.
-	 */
+	// Locator variant of isElementDisplayed, for elements that may legitimately be absent
 	private boolean isElementDisplayed(By locator) {
 		List<WebElement> matches = driver.findElements(locator);
 		return !matches.isEmpty() && isElementDisplayed(matches.get(0));

--- a/ui-test/src/main/java/base/BaseTest.java
+++ b/ui-test/src/main/java/base/BaseTest.java
@@ -68,21 +68,50 @@ public class BaseTest {
 		}
 	}
 
+	/**
+	 * The single place a scenario can be rejected before the driver is created.
+	 *
+	 * <p>Add new skip conditions here rather than in a separate hook class: every
+	 * condition then shares one ordering, one report-entry convention and one
+	 * guarantee that the decision happens before any (possibly remote) session is
+	 * opened. Returns the reason to report, or {@code null} to run the scenario.
+	 */
+	private String skipReasonFor(Scenario scenario) {
+		String bugId = runners.Runner.knownIssues.get(scenario.getName());
+		if (bugId != null) {
+			return "🟠 Skipped due to Known Issue: " + bugId;
+		}
+
+		// CDP network interception is a local-Chrome capability, so @localOnly
+		// scenarios cannot run against BrowserStack.
+		if (scenario.getSourceTagNames().contains("@localOnly")
+				&& Boolean.parseBoolean(EsignetConfigManager.getproperty("runOnBrowserStack"))) {
+			return "⚠️ Requires local Chrome with CDP network interception. Skipped on BrowserStack. "
+					+ "Run with runOnBrowserStack=false to execute.";
+		}
+
+		return null;
+	}
+
 	@Before
 	public void beforeAll(Scenario scenario) {
 		LOGGER.info("Initializing WebDriver...");
 
-		if (runners.Runner.knownIssues.containsKey(scenario.getName())) {
-			String bugId = runners.Runner.knownIssues.get(scenario.getName());
-			LOGGER.info("Skipping Known Issue Scenario: " + scenario.getName() + " | Bug: " + bugId);
-			isKnownIssueScenario.set(true);
-			throw new SkipException("Known Issue - Skipped: " + scenario.getName() + " | " + bugId);
-		}
-		isKnownIssueScenario.set(false);
-
-		totalCount++;
 		String browser = BaseTestUtil.getBrowserForScenario(scenario);
 		String lang = BaseTestUtil.getThreadLocalLanguage();
+		isKnownIssueScenario.set(runners.Runner.knownIssues.containsKey(scenario.getName()));
+
+		String skipReason = skipReasonFor(scenario);
+		if (skipReason != null) {
+			// Create the report entry before skipping so the shared @After has a test
+			// object for *this* scenario rather than whatever the thread ran last.
+			ExtentReportManager.createTest(scenario.getName() + " [" + browser + " | " + lang + "]");
+			ExtentReportManager.getTest().skip(skipReason);
+			LOGGER.info("Skipping scenario: " + scenario.getName() + " - " + skipReason);
+			throw new SkipException(skipReason + " - " + scenario.getName());
+		}
+
+		totalCount++;
 		ExtentReportManager.createTest(scenario.getName() + " [" + browser + " | " + lang + "]");
 		ExtentReportManager
 				.logStep("Scenario Started: " + scenario.getName() + " | Browser: " + browser + " | Language: " + lang);
@@ -204,8 +233,9 @@ public class BaseTest {
 				String bugId = runners.Runner.knownIssues.get(scenario.getName());
 				String bugUrl = "https://mosip.atlassian.net/browse/" + bugId;
 
+				// The report entry already exists - the @Before skip gate creates it
+				// before throwing - so this adds the bug link rather than a second entry.
 				ExtentReportManager.incrementKnownIssue();
-				ExtentReportManager.createTest(scenario.getName());
 				ExtentReportManager.getTest().skip(
 						"🟠 Skipped due to Known Issue → <a href='" + bugUrl + "' target='_blank'>" + bugId + "</a>");
 

--- a/ui-test/src/main/java/base/BaseTest.java
+++ b/ui-test/src/main/java/base/BaseTest.java
@@ -68,22 +68,14 @@ public class BaseTest {
 		}
 	}
 
-	/**
-	 * The single place a scenario can be rejected before the driver is created.
-	 *
-	 * <p>Add new skip conditions here rather than in a separate hook class: every
-	 * condition then shares one ordering, one report-entry convention and one
-	 * guarantee that the decision happens before any (possibly remote) session is
-	 * opened. Returns the reason to report, or {@code null} to run the scenario.
-	 */
+	// Single skip gate, evaluated before the driver is created; returns null to run the scenario
 	private String skipReasonFor(Scenario scenario) {
 		String bugId = runners.Runner.knownIssues.get(scenario.getName());
 		if (bugId != null) {
 			return "🟠 Skipped due to Known Issue: " + bugId;
 		}
 
-		// CDP network interception is a local-Chrome capability, so @localOnly
-		// scenarios cannot run against BrowserStack.
+		// CDP interception is a local-Chrome capability, so @localOnly cannot run on BrowserStack
 		if (scenario.getSourceTagNames().contains("@localOnly")
 				&& Boolean.parseBoolean(EsignetConfigManager.getproperty("runOnBrowserStack"))) {
 			return "⚠️ Requires local Chrome with CDP network interception. Skipped on BrowserStack. "
@@ -103,8 +95,7 @@ public class BaseTest {
 
 		String skipReason = skipReasonFor(scenario);
 		if (skipReason != null) {
-			// Create the report entry before skipping so the shared @After has a test
-			// object for *this* scenario rather than whatever the thread ran last.
+			// Created before skipping so the shared @After reports against this scenario, not the last one
 			ExtentReportManager.createTest(scenario.getName() + " [" + browser + " | " + lang + "]");
 			ExtentReportManager.getTest().skip(skipReason);
 			LOGGER.info("Skipping scenario: " + scenario.getName() + " - " + skipReason);

--- a/ui-test/src/main/java/pages/ErrorHandlerPage.java
+++ b/ui-test/src/main/java/pages/ErrorHandlerPage.java
@@ -14,27 +14,10 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import base.BasePage;
 import utils.EsignetConfigManager;
 
-/**
- * Page object for the "Something went wrong" error handler page
- * (route: /something-went-wrong).
- *
- * The page is rendered by ErrorPageTemplate:
- * - title       -> h1.text-center.text-2xl.font-semibold
- * - description -> p.text-center.text-gray-500
- * The language switcher (from the shared NavBar) is present here as well,
- * so the same ids used across the app apply:
- * - language-select-button (dropdown trigger)
- * - {lang}_language        (dropdown item, e.g. en_language / km_language)
- */
+// Page object for the "Something went wrong" error handler page (route: /something-went-wrong)
 public class ErrorHandlerPage extends BasePage {
 
-	/*
-	 * Match the class attribute per token rather than with '=': the rendered
-	 * markup carries additional utility classes (the title is
-	 * "text-center text-2xl font-semibold"), and an exact match silently stops
-	 * matching the moment a class is added. The XPaths are held as constants so
-	 * the By locators and the @FindBy fields below cannot drift apart.
-	 */
+	// Matched per class token, not with '=': the markup carries extra utility classes
 	private static final String ERROR_TITLE_XPATH = "//h1[contains(@class,'text-center') and contains(@class,'text-2xl')]";
 	private static final String ERROR_DESCRIPTION_XPATH = "//p[contains(@class,'text-center') and contains(@class,'text-gray-500')]";
 
@@ -58,12 +41,11 @@ public class ErrorHandlerPage extends BasePage {
 		return base.endsWith("/") ? base : base + "/";
 	}
 
-	/** Loads the error page directly (no HTTP status code in router state). */
 	public void navigateToErrorPage() {
 		driver.get(signupPortalBaseUrl() + ERROR_ROUTE);
 	}
 
-	/** Loads the signup portal root so a failing API call redirects to the error page. */
+	// Root is loaded so that a failing API call redirects to the error page
 	public void navigateToSignupPortalRoot() {
 		driver.get(signupPortalBaseUrl());
 	}
@@ -84,20 +66,9 @@ public class ErrorHandlerPage extends BasePage {
 		return isElementVisible(errorDescription, "Check error handler description displayed");
 	}
 
-	/**
-	 * Extra time the redirect needs on top of the configured wait.
-	 *
-	 * <p>The app's react-query client (signup-ui App.tsx) retries any non-4XX
-	 * settings response three times, and react-query's default backoff is
-	 * exponential - 1s + 2s + 4s. The 5XX examples in the outline therefore cannot
-	 * reach the error route until that budget is spent, while the 4XX ones are not
-	 * retried at all and redirect immediately. This is added to the configured
-	 * timeout rather than replacing it, so the wait still scales with
-	 * explicitWaitTimeout instead of being an unexplained constant.
-	 */
+	// Covers react-query's three retries of a non-4XX settings response (1s + 2s + 4s backoff)
 	private static final Duration REDIRECT_RETRY_BUDGET = Duration.ofSeconds(7);
 
-	/** Waits until the app has redirected to the error handler route. */
 	public boolean waitForErrorPage() {
 		Duration timeout = Duration.ofSeconds(EsignetConfigManager.getTimeout()).plus(REDIRECT_RETRY_BUDGET);
 		try {
@@ -125,6 +96,5 @@ public class ErrorHandlerPage extends BasePage {
 		}
 	}
 
-	// Language switching is inherited from BasePage.switchLanguage(..): the
-	// dropdown here is the shared NavBar one, not an error-page control.
+	// Language switching is inherited from BasePage.switchLanguage(..)
 }

--- a/ui-test/src/main/java/pages/ErrorHandlerPage.java
+++ b/ui-test/src/main/java/pages/ErrorHandlerPage.java
@@ -1,0 +1,130 @@
+package pages;
+
+import java.time.Duration;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import base.BasePage;
+import utils.EsignetConfigManager;
+
+/**
+ * Page object for the "Something went wrong" error handler page
+ * (route: /something-went-wrong).
+ *
+ * The page is rendered by ErrorPageTemplate:
+ * - title       -> h1.text-center.text-2xl.font-semibold
+ * - description -> p.text-center.text-gray-500
+ * The language switcher (from the shared NavBar) is present here as well,
+ * so the same ids used across the app apply:
+ * - language-select-button (dropdown trigger)
+ * - {lang}_language        (dropdown item, e.g. en_language / km_language)
+ */
+public class ErrorHandlerPage extends BasePage {
+
+	/*
+	 * Match the class attribute per token rather than with '=': the rendered
+	 * markup carries additional utility classes (the title is
+	 * "text-center text-2xl font-semibold"), and an exact match silently stops
+	 * matching the moment a class is added. The XPaths are held as constants so
+	 * the By locators and the @FindBy fields below cannot drift apart.
+	 */
+	private static final String ERROR_TITLE_XPATH = "//h1[contains(@class,'text-center') and contains(@class,'text-2xl')]";
+	private static final String ERROR_DESCRIPTION_XPATH = "//p[contains(@class,'text-center') and contains(@class,'text-gray-500')]";
+
+	private static final By ERROR_TITLE = By.xpath(ERROR_TITLE_XPATH);
+	private static final By ERROR_DESCRIPTION = By.xpath(ERROR_DESCRIPTION_XPATH);
+	private static final String ERROR_ROUTE = "something-went-wrong";
+
+	public ErrorHandlerPage(WebDriver driver) {
+		super(driver);
+		PageFactory.initElements(driver, this);
+	}
+
+	@FindBy(xpath = ERROR_TITLE_XPATH)
+	WebElement errorTitle;
+
+	@FindBy(xpath = ERROR_DESCRIPTION_XPATH)
+	WebElement errorDescription;
+
+	private String signupPortalBaseUrl() {
+		String base = EsignetConfigManager.getSignupPortalUrl();
+		return base.endsWith("/") ? base : base + "/";
+	}
+
+	/** Loads the error page directly (no HTTP status code in router state). */
+	public void navigateToErrorPage() {
+		driver.get(signupPortalBaseUrl() + ERROR_ROUTE);
+	}
+
+	/** Loads the signup portal root so a failing API call redirects to the error page. */
+	public void navigateToSignupPortalRoot() {
+		driver.get(signupPortalBaseUrl());
+	}
+
+	public String getErrorTitle() {
+		return getText(errorTitle, "Get error handler page title");
+	}
+
+	public String getErrorDescription() {
+		return getText(errorDescription, "Get error handler page description");
+	}
+
+	public boolean isErrorTitleDisplayed() {
+		return isElementVisible(errorTitle, "Check error handler title displayed");
+	}
+
+	public boolean isErrorDescriptionDisplayed() {
+		return isElementVisible(errorDescription, "Check error handler description displayed");
+	}
+
+	/**
+	 * Extra time the redirect needs on top of the configured wait.
+	 *
+	 * <p>The app's react-query client (signup-ui App.tsx) retries any non-4XX
+	 * settings response three times, and react-query's default backoff is
+	 * exponential - 1s + 2s + 4s. The 5XX examples in the outline therefore cannot
+	 * reach the error route until that budget is spent, while the 4XX ones are not
+	 * retried at all and redirect immediately. This is added to the configured
+	 * timeout rather than replacing it, so the wait still scales with
+	 * explicitWaitTimeout instead of being an unexplained constant.
+	 */
+	private static final Duration REDIRECT_RETRY_BUDGET = Duration.ofSeconds(7);
+
+	/** Waits until the app has redirected to the error handler route. */
+	public boolean waitForErrorPage() {
+		Duration timeout = Duration.ofSeconds(EsignetConfigManager.getTimeout()).plus(REDIRECT_RETRY_BUDGET);
+		try {
+			new WebDriverWait(driver, timeout).until(ExpectedConditions.urlContains(ERROR_ROUTE));
+			return isElementVisible(errorTitle, "Wait for error handler page");
+		} catch (TimeoutException e) {
+			return false;
+		}
+	}
+
+	public boolean waitForTitle(String expected) {
+		return waitForText(ERROR_TITLE, expected);
+	}
+
+	public boolean waitForDescription(String expected) {
+		return waitForText(ERROR_DESCRIPTION, expected);
+	}
+
+	private boolean waitForText(By locator, String expected) {
+		try {
+			return new WebDriverWait(driver, Duration.ofSeconds(EsignetConfigManager.getTimeout()))
+					.until(ExpectedConditions.textToBe(locator, expected));
+		} catch (TimeoutException e) {
+			return false;
+		}
+	}
+
+	// Language switching is inherited from BasePage.switchLanguage(..): the
+	// dropdown here is the shared NavBar one, not an error-page control.
+}

--- a/ui-test/src/main/java/pages/ForgetPasswordPage.java
+++ b/ui-test/src/main/java/pages/ForgetPasswordPage.java
@@ -15,6 +15,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import base.BasePage;
 import utils.EsignetUtil;
 import utils.EsignetUtil.RegisteredDetails;
+import utils.WaitUtil;
 
 public class ForgetPasswordPage extends BasePage {
 
@@ -498,7 +499,7 @@ public class ForgetPasswordPage extends BasePage {
 
 	public WebElement getIdentifierFieldElement() {
 		String fieldId = EsignetUtil.getIdentifierFieldId();
-		return driver.findElement(By.id(fieldId));
+		return WaitUtil.waitForVisibility(driver, By.id(fieldId));
 	}
 
 	public void enterIdentifierValue(String value) {
@@ -511,7 +512,7 @@ public class ForgetPasswordPage extends BasePage {
 		String mandatoryLang = EsignetUtil.getMandatoryLanguage();
 		String fieldId = "fullName_" + mandatoryLang;
 
-		return driver.findElement(By.id(fieldId));
+		return WaitUtil.waitForVisibility(driver, By.id(fieldId));
 	}
 
 	public void enterFullName(String value) {

--- a/ui-test/src/main/java/pages/LoginOptionsPage.java
+++ b/ui-test/src/main/java/pages/LoginOptionsPage.java
@@ -407,4 +407,12 @@ public class LoginOptionsPage extends BasePage {
 		return welcomePageOfRelyingParty.getText();
 	}
 
+	public String getEnteredPassword() {
+		return getElementValue(passwordField, "read entered password value");
+	}
+
+	public boolean isLoginButtonDisabled() {
+		return !isButtonEnabled(loginButton, "check login button is disabled");
+	}
+
 }

--- a/ui-test/src/main/java/pages/RegistrationPage.java
+++ b/ui-test/src/main/java/pages/RegistrationPage.java
@@ -2,6 +2,7 @@ package pages;
 
 import base.BasePage;
 import utils.EsignetUtil;
+import utils.WaitUtil;
 
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -275,7 +276,7 @@ public class RegistrationPage extends BasePage {
 
 	public WebElement getIdentifierFieldElement() {
 		String fieldId = EsignetUtil.getIdentifierFieldId();
-		return driver.findElement(By.id(fieldId));
+		return WaitUtil.waitForVisibility(driver, By.id(fieldId));
 	}
 
 	public void enterIdentifierValue(String value) {
@@ -403,6 +404,8 @@ public class RegistrationPage extends BasePage {
 	}
 
 	public void clickOnVerifyOtpButton() {
+		// The Verify button is enabled only once the entered OTP passes form
+		// validation; clickOnElement waits for clickability, not just visibility.
 		clickOnElement(verifyOtpButton, "Click verify OTP Button");
 	}
 
@@ -814,8 +817,6 @@ public class RegistrationPage extends BasePage {
 	}
 
 	public void clickOnCaptureButton() {
-		new WebDriverWait(driver, Duration.ofSeconds(10))
-				.until(ExpectedConditions.elementToBeClickable(captureButton));
 		clickOnElement(captureButton, "click on capture button");
 	}
 

--- a/ui-test/src/main/java/pages/RegistrationPage.java
+++ b/ui-test/src/main/java/pages/RegistrationPage.java
@@ -404,8 +404,7 @@ public class RegistrationPage extends BasePage {
 	}
 
 	public void clickOnVerifyOtpButton() {
-		// The Verify button is enabled only once the entered OTP passes form
-		// validation; clickOnElement waits for clickability, not just visibility.
+		// Verify is enabled only once the entered OTP passes form validation
 		clickOnElement(verifyOtpButton, "Click verify OTP Button");
 	}
 

--- a/ui-test/src/main/java/pages/SignupFormFieldPage.java
+++ b/ui-test/src/main/java/pages/SignupFormFieldPage.java
@@ -1,0 +1,318 @@
+package pages;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.time.Duration;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.LocalFileDetector;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import base.BasePage;
+
+/**
+ * Page object for the dynamically rendered (JsonFormBuilder) Setup Account form
+ * fields - radio (e.g. gender), textarea (e.g. details) and file upload (e.g.
+ * passport / photo). Locators follow the conventions already used by
+ * {@link SignupFormDynamicFiller} and {@link RegistrationPage}: the builder gives
+ * each field a wrapper carrying {@code data-field-id}, marks an invalid control
+ * with {@code class="error"} and renders that control's message into a
+ * {@code .error-message} element inside the same wrapper. Anything read for a
+ * field is therefore looked up within that wrapper.
+ */
+public class SignupFormFieldPage extends BasePage {
+
+	private static final Logger logger = Logger.getLogger(SignupFormFieldPage.class);
+
+	public SignupFormFieldPage(WebDriver driver) {
+		super(driver);
+	}
+
+	// ---- Generic helpers ------------------------------------------------------
+
+	private By radioGroup(String fieldId) {
+		return By.xpath("//input[@type='radio' and (@name='" + fieldId + "' or @data-field-id='" + fieldId + "')]");
+	}
+
+	private By textareaBy(String fieldId) {
+		return By.xpath("//textarea[@id='" + fieldId + "' or @data-field-id='" + fieldId + "' or starts-with(@id,'"
+				+ fieldId + "')]");
+	}
+
+	private By fileInputBy(String fieldId) {
+		return By.xpath("//input[@type='file' and (contains(@id,'" + fieldId + "') or contains(@data-field-id,'"
+				+ fieldId + "'))]");
+	}
+
+	private By labelBy(String fieldId) {
+		return By.xpath("//label[@for='" + fieldId + "' or contains(@for,'" + fieldId + "')]");
+	}
+
+	/**
+	 * XPath predicate matching a whole class token, so 'error' does not also match
+	 * 'error-icon' / 'upload-error-area' the way a bare contains(@class,...) would.
+	 */
+	private static String hasClass(String cssClass) {
+		return "contains(concat(' ', normalize-space(@class), ' '), ' " + cssClass + " ')";
+	}
+
+	/**
+	 * The part of the page that belongs to one field, used to bound every lookup so
+	 * it cannot reach a neighbouring field or unrelated page chrome.
+	 *
+	 * <p>The builder gives each field a container carrying data-field-id, e.g.
+	 * {@code <div class="form-field file-upload" data-field-id="passport">}. Most
+	 * field types keep their message inside that container, but a radio group
+	 * renders it as a <em>sibling</em> of the container, inside the enclosing
+	 * {@code .form-field-group}. The scope is therefore the enclosing
+	 * {@code .form-field-group} when there is one, and the container itself
+	 * otherwise.
+	 */
+	private String fieldScopeXpath(String fieldId) {
+		String container = "//*[@data-field-id='" + fieldId + "']";
+		return "(" + container + "/ancestor-or-self::*[" + hasClass("form-field-group") + "][1] | " + container + ")";
+	}
+
+	/**
+	 * True when the field's own control is flagged invalid.
+	 *
+	 * <p>The builder marks an invalid control with {@code class="error"}; the
+	 * aria-invalid check is retained for controls rendered outside the builder. The
+	 * id is matched exactly rather than with starts-with(), which would also match
+	 * this field's sub-controls (a file field renders {@code <id>_docType} and
+	 * {@code <id>_refId}) and report their state as this field's.
+	 */
+	public boolean isFieldInvalid(String fieldId) {
+		String identifies = "(@id='" + fieldId + "' or @name='" + fieldId + "' or @data-field-id='" + fieldId + "')";
+		List<WebElement> flagged = driver.findElements(
+				By.xpath("//*[" + identifies + " and (@aria-invalid='true' or " + hasClass("error") + ")]"));
+		return !flagged.isEmpty();
+	}
+
+	/**
+	 * First non-empty inline error text belonging to this field, if any.
+	 *
+	 * <p>The builder renders inline errors as
+	 * {@code <div class="error-message">} holding a {@code <span class="error-text">},
+	 * and empties that div when the error clears. The search is bounded to this
+	 * field's scope, and skips the nested {@code .file-subfield} blocks a
+	 * file field renders for document type / reference id - those carry their own
+	 * error text, which belongs to the sub-field and not to this field. (A file
+	 * upload dispatches an input event at its document-type dropdown after a
+	 * successful upload, so that sub-field can legitimately show a "required"
+	 * error while the upload itself was accepted.) Messages sitting inside another
+	 * field's container are excluded too, so a group holding more than one field
+	 * cannot report its neighbour's error as this field's.
+	 */
+	public String getFieldErrorText(String fieldId) {
+		List<WebElement> errors = driver.findElements(By.xpath(fieldScopeXpath(fieldId) + "//*["
+				+ hasClass("error-message")
+				+ " and not(ancestor::*[" + hasClass("file-subfield") + "])"
+				+ " and not(ancestor::*[@data-field-id and not(@data-field-id='" + fieldId + "')])]"));
+		for (WebElement e : errors) {
+			String text = e.getText();
+			if (text != null && !text.trim().isEmpty()) {
+				return text.trim();
+			}
+		}
+		return "";
+	}
+
+	private WebElement waitForVisible(By locator) {
+		return new WebDriverWait(driver, Duration.ofSeconds(10))
+				.until(ExpectedConditions.visibilityOfElementLocated(locator));
+	}
+
+	/**
+	 * Waits (up to the standard timeout) for at least one matching element to be
+	 * present in the DOM, returning {@code false} instead of throwing on timeout.
+	 * Presence (not visibility) is used so form hydration is tolerated without
+	 * false negatives on inputs that are present but visually styled/hidden
+	 * (e.g. radio and file inputs behind custom controls).
+	 */
+	private boolean waitUntilRendered(By locator) {
+		try {
+			new WebDriverWait(driver, Duration.ofSeconds(10))
+					.until(ExpectedConditions.presenceOfElementLocated(locator));
+			return true;
+		} catch (org.openqa.selenium.TimeoutException e) {
+			return false;
+		}
+	}
+
+	// ---- Radio ----------------------------------------------------------------
+
+	public List<WebElement> getRadioOptions(String fieldId) {
+		return driver.findElements(radioGroup(fieldId));
+	}
+
+	public boolean isRadioFieldRendered(String fieldId) {
+		return waitUntilRendered(radioGroup(fieldId));
+	}
+
+	public boolean isRadioLabelRendered(String fieldId) {
+		return waitUntilRendered(labelBy(fieldId));
+	}
+
+	public void selectRadioOption(String fieldId, int index) {
+		List<WebElement> radios = getRadioOptions(fieldId);
+		if (index < 0 || index >= radios.size()) {
+			throw new IllegalArgumentException("Cannot select radio option " + index + " for field '" + fieldId
+					+ "': " + radios.size() + " option(s) available");
+		}
+		WebElement radio = radios.get(index);
+		((JavascriptExecutor) driver).executeScript("arguments[0].scrollIntoView({block:'center'});", radio);
+		((JavascriptExecutor) driver).executeScript("arguments[0].click();", radio);
+	}
+
+	public int getSelectedRadioCount(String fieldId) {
+		int selected = 0;
+		for (WebElement radio : getRadioOptions(fieldId)) {
+			if (radio.isSelected()) {
+				selected++;
+			}
+		}
+		return selected;
+	}
+
+	/** Selects two different options in turn and returns the final selected count. */
+	public int selectTwoOptionsAndCountSelected(String fieldId) {
+		List<WebElement> radios = getRadioOptions(fieldId);
+		if (radios.size() < 2) {
+			return getSelectedRadioCount(fieldId);
+		}
+		selectRadioOption(fieldId, 0);
+		selectRadioOption(fieldId, 1);
+		return getSelectedRadioCount(fieldId);
+	}
+
+	// ---- Textarea -------------------------------------------------------------
+
+	public boolean isTextareaRendered(String fieldId) {
+		return waitUntilRendered(textareaBy(fieldId));
+	}
+
+	public WebElement getTextarea(String fieldId) {
+		return waitForVisible(textareaBy(fieldId));
+	}
+
+	public int getTextareaRows(String fieldId) {
+		String rows = getTextarea(fieldId).getAttribute("rows");
+		try {
+			return rows == null ? -1 : Integer.parseInt(rows.trim());
+		} catch (NumberFormatException e) {
+			return -1;
+		}
+	}
+
+	public String getTextareaPlaceholder(String fieldId) {
+		return getTextarea(fieldId).getAttribute("placeholder");
+	}
+
+	public void enterTextarea(String fieldId, String value) {
+		WebElement ta = getTextarea(fieldId);
+		ta.clear();
+		ta.sendKeys(value);
+	}
+
+	public String getTextareaValue(String fieldId) {
+		return getTextarea(fieldId).getAttribute("value");
+	}
+
+	// ---- File upload ----------------------------------------------------------
+
+	public boolean isFileUploadRendered(String fieldId) {
+		return waitUntilRendered(fileInputBy(fieldId));
+	}
+
+	public boolean isFileUploadLabelRendered(String fieldId) {
+		return isFileUploadRendered(fieldId) && waitUntilRendered(labelBy(fieldId));
+	}
+
+	public void uploadClasspathFile(String fieldId, String classpathResource, String fileName) throws IOException {
+		Path tempPath = createRestrictedTempFile("upload-", "-" + fileName);
+		try (InputStream in = getClass().getClassLoader().getResourceAsStream(classpathResource)) {
+			if (in == null) {
+				throw new IOException("Upload resource not found: " + classpathResource);
+			}
+			Files.copy(in, tempPath, StandardCopyOption.REPLACE_EXISTING);
+		}
+		sendFileToInput(fieldId, tempPath.toFile());
+		logger.info("Uploaded supported file for " + fieldId + ": " + fileName);
+	}
+
+	/** Creates a throwaway unsupported (.exe) file on the fly and uploads it. */
+	public void uploadUnsupportedFile(String fieldId) throws IOException {
+		Path tempPath = createRestrictedTempFile("malware-", ".exe");
+		Files.write(tempPath, new byte[] { 0x4D, 0x5A });
+		sendFileToInput(fieldId, tempPath.toFile());
+		logger.info("Uploaded unsupported .exe file for " + fieldId);
+	}
+
+	/**
+	 * Creates a temp file restricted to the owner. Uses POSIX owner-only
+	 * permissions where the filesystem supports them, falling back to the File
+	 * permission API on non-POSIX platforms (e.g. Windows).
+	 */
+	private Path createRestrictedTempFile(String prefix, String suffix) throws IOException {
+		Path tempPath;
+		try {
+			tempPath = Files.createTempFile(prefix, suffix,
+					PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------")));
+		} catch (UnsupportedOperationException e) {
+			tempPath = Files.createTempFile(prefix, suffix);
+			File f = tempPath.toFile();
+			boolean restricted = f.setReadable(false, false);
+			restricted = f.setReadable(true, true) && restricted;
+			restricted = f.setWritable(false, false) && restricted;
+			restricted = f.setWritable(true, true) && restricted;
+			if (!restricted) {
+				logger.warn("Could not fully restrict permissions on temp file: " + tempPath);
+			}
+		}
+		tempPath.toFile().deleteOnExit();
+		return tempPath;
+	}
+
+	private void sendFileToInput(String fieldId, File file) {
+		if (driver instanceof RemoteWebDriver) {
+			((RemoteWebDriver) driver).setFileDetector(new LocalFileDetector());
+		}
+		WebElement input = waitForVisible(fileInputBy(fieldId));
+		input.sendKeys(file.getAbsolutePath());
+	}
+
+	public boolean isUnsupportedFileErrorShown(String fieldId) {
+		return isFieldInvalid(fieldId) || !getFieldErrorText(fieldId).isEmpty();
+	}
+
+	/**
+	 * Waits (up to the standard timeout) for the field's validation to settle to a
+	 * valid state: {@code aria-invalid} cleared and no inline error text. This lets
+	 * asynchronous client-side validation finish after an upload before acceptance
+	 * is asserted. Returns {@code false} if it does not become valid within the
+	 * timeout.
+	 */
+	public boolean waitForFieldValid(String fieldId) {
+		try {
+			new WebDriverWait(driver, Duration.ofSeconds(10))
+					.until(d -> !isUnsupportedFileErrorShown(fieldId));
+			return true;
+		} catch (org.openqa.selenium.TimeoutException e) {
+			return false;
+		}
+	}
+
+}

--- a/ui-test/src/main/java/pages/SignupFormFieldPage.java
+++ b/ui-test/src/main/java/pages/SignupFormFieldPage.java
@@ -22,16 +22,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 
 import base.BasePage;
 
-/**
- * Page object for the dynamically rendered (JsonFormBuilder) Setup Account form
- * fields - radio (e.g. gender), textarea (e.g. details) and file upload (e.g.
- * passport / photo). Locators follow the conventions already used by
- * {@link SignupFormDynamicFiller} and {@link RegistrationPage}: the builder gives
- * each field a wrapper carrying {@code data-field-id}, marks an invalid control
- * with {@code class="error"} and renders that control's message into a
- * {@code .error-message} element inside the same wrapper. Anything read for a
- * field is therefore looked up within that wrapper.
- */
+// Page object for the dynamically rendered (JsonFormBuilder) Setup Account form fields
 public class SignupFormFieldPage extends BasePage {
 
 	private static final Logger logger = Logger.getLogger(SignupFormFieldPage.class);
@@ -60,40 +51,18 @@ public class SignupFormFieldPage extends BasePage {
 		return By.xpath("//label[@for='" + fieldId + "' or contains(@for,'" + fieldId + "')]");
 	}
 
-	/**
-	 * XPath predicate matching a whole class token, so 'error' does not also match
-	 * 'error-icon' / 'upload-error-area' the way a bare contains(@class,...) would.
-	 */
+	// Matches a whole class token, so 'error' does not also match 'error-icon'
 	private static String hasClass(String cssClass) {
 		return "contains(concat(' ', normalize-space(@class), ' '), ' " + cssClass + " ')";
 	}
 
-	/**
-	 * The part of the page that belongs to one field, used to bound every lookup so
-	 * it cannot reach a neighbouring field or unrelated page chrome.
-	 *
-	 * <p>The builder gives each field a container carrying data-field-id, e.g.
-	 * {@code <div class="form-field file-upload" data-field-id="passport">}. Most
-	 * field types keep their message inside that container, but a radio group
-	 * renders it as a <em>sibling</em> of the container, inside the enclosing
-	 * {@code .form-field-group}. The scope is therefore the enclosing
-	 * {@code .form-field-group} when there is one, and the container itself
-	 * otherwise.
-	 */
+	// Bounds lookups to one field; the group is preferred since a radio renders its message outside the container
 	private String fieldScopeXpath(String fieldId) {
 		String container = "//*[@data-field-id='" + fieldId + "']";
 		return "(" + container + "/ancestor-or-self::*[" + hasClass("form-field-group") + "][1] | " + container + ")";
 	}
 
-	/**
-	 * True when the field's own control is flagged invalid.
-	 *
-	 * <p>The builder marks an invalid control with {@code class="error"}; the
-	 * aria-invalid check is retained for controls rendered outside the builder. The
-	 * id is matched exactly rather than with starts-with(), which would also match
-	 * this field's sub-controls (a file field renders {@code <id>_docType} and
-	 * {@code <id>_refId}) and report their state as this field's.
-	 */
+	// Exact id match, since starts-with() would also pick up sub-controls like <id>_docType
 	public boolean isFieldInvalid(String fieldId) {
 		String identifies = "(@id='" + fieldId + "' or @name='" + fieldId + "' or @data-field-id='" + fieldId + "')";
 		List<WebElement> flagged = driver.findElements(
@@ -101,21 +70,7 @@ public class SignupFormFieldPage extends BasePage {
 		return !flagged.isEmpty();
 	}
 
-	/**
-	 * First non-empty inline error text belonging to this field, if any.
-	 *
-	 * <p>The builder renders inline errors as
-	 * {@code <div class="error-message">} holding a {@code <span class="error-text">},
-	 * and empties that div when the error clears. The search is bounded to this
-	 * field's scope, and skips the nested {@code .file-subfield} blocks a
-	 * file field renders for document type / reference id - those carry their own
-	 * error text, which belongs to the sub-field and not to this field. (A file
-	 * upload dispatches an input event at its document-type dropdown after a
-	 * successful upload, so that sub-field can legitimately show a "required"
-	 * error while the upload itself was accepted.) Messages sitting inside another
-	 * field's container are excluded too, so a group holding more than one field
-	 * cannot report its neighbour's error as this field's.
-	 */
+	// Sub-field and neighbouring-field messages are excluded so they are not reported as this field's
 	public String getFieldErrorText(String fieldId) {
 		List<WebElement> errors = driver.findElements(By.xpath(fieldScopeXpath(fieldId) + "//*["
 				+ hasClass("error-message")
@@ -135,13 +90,7 @@ public class SignupFormFieldPage extends BasePage {
 				.until(ExpectedConditions.visibilityOfElementLocated(locator));
 	}
 
-	/**
-	 * Waits (up to the standard timeout) for at least one matching element to be
-	 * present in the DOM, returning {@code false} instead of throwing on timeout.
-	 * Presence (not visibility) is used so form hydration is tolerated without
-	 * false negatives on inputs that are present but visually styled/hidden
-	 * (e.g. radio and file inputs behind custom controls).
-	 */
+	// Presence, not visibility: radio and file inputs sit hidden behind custom controls
 	private boolean waitUntilRendered(By locator) {
 		try {
 			new WebDriverWait(driver, Duration.ofSeconds(10))
@@ -187,7 +136,6 @@ public class SignupFormFieldPage extends BasePage {
 		return selected;
 	}
 
-	/** Selects two different options in turn and returns the final selected count. */
 	public int selectTwoOptionsAndCountSelected(String fieldId) {
 		List<WebElement> radios = getRadioOptions(fieldId);
 		if (radios.size() < 2) {
@@ -253,7 +201,6 @@ public class SignupFormFieldPage extends BasePage {
 		logger.info("Uploaded supported file for " + fieldId + ": " + fileName);
 	}
 
-	/** Creates a throwaway unsupported (.exe) file on the fly and uploads it. */
 	public void uploadUnsupportedFile(String fieldId) throws IOException {
 		Path tempPath = createRestrictedTempFile("malware-", ".exe");
 		Files.write(tempPath, new byte[] { 0x4D, 0x5A });
@@ -261,11 +208,7 @@ public class SignupFormFieldPage extends BasePage {
 		logger.info("Uploaded unsupported .exe file for " + fieldId);
 	}
 
-	/**
-	 * Creates a temp file restricted to the owner. Uses POSIX owner-only
-	 * permissions where the filesystem supports them, falling back to the File
-	 * permission API on non-POSIX platforms (e.g. Windows).
-	 */
+	// Falls back to the File permission API where POSIX permissions are unsupported (e.g. Windows)
 	private Path createRestrictedTempFile(String prefix, String suffix) throws IOException {
 		Path tempPath;
 		try {
@@ -298,13 +241,7 @@ public class SignupFormFieldPage extends BasePage {
 		return isFieldInvalid(fieldId) || !getFieldErrorText(fieldId).isEmpty();
 	}
 
-	/**
-	 * Waits (up to the standard timeout) for the field's validation to settle to a
-	 * valid state: {@code aria-invalid} cleared and no inline error text. This lets
-	 * asynchronous client-side validation finish after an upload before acceptance
-	 * is asserted. Returns {@code false} if it does not become valid within the
-	 * timeout.
-	 */
+	// Lets asynchronous client-side validation settle after an upload before acceptance is asserted
 	public boolean waitForFieldValid(String fieldId) {
 		try {
 			new WebDriverWait(driver, Duration.ofSeconds(10))

--- a/ui-test/src/main/java/pages/TransactionTimeoutPopupPage.java
+++ b/ui-test/src/main/java/pages/TransactionTimeoutPopupPage.java
@@ -8,6 +8,8 @@ import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import base.BasePage;
 import utils.EsignetConfigManager;
@@ -24,6 +26,8 @@ import utils.WaitUtil;
  * </ul>
  */
 public class TransactionTimeoutPopupPage extends BasePage {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(TransactionTimeoutPopupPage.class);
 
 	private static final By POPUP = By.cssSelector("[role='alertdialog']");
 	private static final By TITLE = By.xpath("//*[@role='alertdialog']//h2");
@@ -70,6 +74,7 @@ public class TransactionTimeoutPopupPage extends BasePage {
 					.executeScript("return window.localStorage.getItem('esignet-signup-language');");
 			return (lang == null || lang.toString().isBlank()) ? "en" : lang.toString();
 		} catch (Exception e) {
+			LOGGER.warn("Could not read the active language from localStorage, falling back to 'en'", e);
 			return "en";
 		}
 	}

--- a/ui-test/src/main/java/pages/TransactionTimeoutPopupPage.java
+++ b/ui-test/src/main/java/pages/TransactionTimeoutPopupPage.java
@@ -1,0 +1,92 @@
+package pages;
+
+import java.time.Duration;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import base.BasePage;
+import utils.EsignetConfigManager;
+import utils.WaitUtil;
+
+/**
+ * Page object for the signup critical-error popup (the {@code SignUpPopover}
+ * rendered on {@code invalid_transaction}). It is a Radix AlertDialog:
+ * <ul>
+ * <li>container -&gt; role="alertdialog"</li>
+ * <li>title     -&gt; h2 (shows the localized "error" title, e.g. "Error!")</li>
+ * <li>message   -&gt; p (localized error description)</li>
+ * <li>action    -&gt; button#okay-button (localized "okay" text)</li>
+ * </ul>
+ */
+public class TransactionTimeoutPopupPage extends BasePage {
+
+	private static final By POPUP = By.cssSelector("[role='alertdialog']");
+	private static final By TITLE = By.xpath("//*[@role='alertdialog']//h2");
+	private static final By MESSAGE = By.xpath("//*[@role='alertdialog']//p");
+	private static final By OKAY_BUTTON = By.id("okay-button");
+
+	public TransactionTimeoutPopupPage(WebDriver driver) {
+		super(driver);
+	}
+
+	public boolean isPopupDisplayed() {
+		return isVisible(POPUP);
+	}
+
+	public boolean isOkayButtonDisplayed() {
+		return isVisible(OKAY_BUTTON);
+	}
+
+	public String getPopupTitle() {
+		return textOf(TITLE);
+	}
+
+	public String getPopupMessage() {
+		return textOf(MESSAGE);
+	}
+
+	public String getOkayButtonText() {
+		return textOf(OKAY_BUTTON);
+	}
+
+	public void clickOkay() {
+		clickOnElement(WaitUtil.waitForClickability(driver, OKAY_BUTTON),
+				"Click Okay on the transaction timeout popup");
+	}
+
+	/**
+	 * @return the app's active UI language code (e.g. "en" / "km"), read from the
+	 *         same localStorage key the signup portal persists it under; defaults
+	 *         to "en" if unavailable, so locale lookups match what is rendered.
+	 */
+	public String getActiveLanguage() {
+		try {
+			Object lang = ((JavascriptExecutor) driver)
+					.executeScript("return window.localStorage.getItem('esignet-signup-language');");
+			return (lang == null || lang.toString().isBlank()) ? "en" : lang.toString();
+		} catch (Exception e) {
+			return "en";
+		}
+	}
+
+	private boolean isVisible(By locator) {
+		try {
+			return newWait().until(ExpectedConditions.visibilityOfElementLocated(locator)).isDisplayed();
+		} catch (TimeoutException e) {
+			return false;
+		}
+	}
+
+	private String textOf(By locator) {
+		return newWait().until(ExpectedConditions.visibilityOfElementLocated(locator)).getText().trim();
+	}
+
+	private WebDriverWait newWait() {
+		return new WebDriverWait(driver, Duration.ofSeconds(EsignetConfigManager.getTimeout()));
+	}
+}

--- a/ui-test/src/main/java/pages/TransactionTimeoutPopupPage.java
+++ b/ui-test/src/main/java/pages/TransactionTimeoutPopupPage.java
@@ -15,16 +15,7 @@ import base.BasePage;
 import utils.EsignetConfigManager;
 import utils.WaitUtil;
 
-/**
- * Page object for the signup critical-error popup (the {@code SignUpPopover}
- * rendered on {@code invalid_transaction}). It is a Radix AlertDialog:
- * <ul>
- * <li>container -&gt; role="alertdialog"</li>
- * <li>title     -&gt; h2 (shows the localized "error" title, e.g. "Error!")</li>
- * <li>message   -&gt; p (localized error description)</li>
- * <li>action    -&gt; button#okay-button (localized "okay" text)</li>
- * </ul>
- */
+// Page object for the signup critical-error popup rendered on invalid_transaction
 public class TransactionTimeoutPopupPage extends BasePage {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(TransactionTimeoutPopupPage.class);
@@ -63,11 +54,7 @@ public class TransactionTimeoutPopupPage extends BasePage {
 				"Click Okay on the transaction timeout popup");
 	}
 
-	/**
-	 * @return the app's active UI language code (e.g. "en" / "km"), read from the
-	 *         same localStorage key the signup portal persists it under; defaults
-	 *         to "en" if unavailable, so locale lookups match what is rendered.
-	 */
+	// Read from the localStorage key the portal persists it under, so locale lookups match what is rendered
 	public String getActiveLanguage() {
 		try {
 			Object lang = ((JavascriptExecutor) driver)

--- a/ui-test/src/main/java/stepdefinitions/ErrorHandlerStepDef.java
+++ b/ui-test/src/main/java/stepdefinitions/ErrorHandlerStepDef.java
@@ -1,0 +1,103 @@
+package stepdefinitions;
+
+import static org.junit.Assert.assertTrue;
+
+import org.openqa.selenium.WebDriver;
+
+import base.BaseTest;
+import io.cucumber.java.After;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import pages.ErrorHandlerPage;
+import utils.LocaleTextUtil;
+import utils.NetworkErrorInterceptor;
+
+/**
+ * Steps for the "Something went wrong" error handler page.
+ *
+ * Two layers are covered:
+ * - Generic page + language switch via direct navigation (runs everywhere).
+ * - Real HTTP 4XX/5XX (400/403/404/405/415/500/502/503/504) forced through CDP
+ *   interception (@localOnly), which drives the app's axios error interceptor
+ *   into the error page carrying the status code, so the title renders the HTTP
+ *   reason phrase.
+ */
+public class ErrorHandlerStepDef {
+
+	private static final String TITLE_KEY = "something_went_wrong";
+	private static final String DETAIL_KEY = "something_went_wrong_detail";
+	// Only the /settings call goes through the app's ApiService response
+	// interceptor and is guaranteed on every page load (via the shared NavBar).
+	private static final String SETTINGS_API = "/v1/signup/settings";
+
+	private final WebDriver driver;
+	private final ErrorHandlerPage errorPage;
+	private NetworkErrorInterceptor interceptor;
+
+	public ErrorHandlerStepDef(BaseTest baseTest) {
+		this.driver = BaseTest.getDriver();
+		this.errorPage = new ErrorHandlerPage(driver);
+	}
+
+	// ---- Generic error page (direct navigation) -------------------------------
+
+	@Given("user navigates directly to the error handler page")
+	public void userNavigatesDirectlyToErrorHandlerPage() {
+		errorPage.navigateToErrorPage();
+		assertTrue("Error handler page did not load", errorPage.isErrorTitleDisplayed());
+	}
+
+	// ---- Forced HTTP 5XX (CDP, local only) ------------------------------------
+
+	@Given("the signup settings API is forced to return HTTP {int}")
+	public void forceSettingsApiToReturn(int statusCode) {
+		interceptor = new NetworkErrorInterceptor(driver, SETTINGS_API, statusCode);
+	}
+
+	@When("user navigates to the signup portal to trigger the error")
+	public void navigateToSignupPortalToTriggerError() {
+		errorPage.navigateToSignupPortalRoot();
+		assertTrue("App did not redirect to the error handler page after the forced 5XX",
+				errorPage.waitForErrorPage());
+	}
+
+	@Then("verify the error handler page title shows the reason phrase {string}")
+	public void verifyErrorTitleShowsReasonPhrase(String reasonPhrase) {
+		assertTrue("Expected error title '" + reasonPhrase + "' but was '" + errorPage.getErrorTitle() + "'",
+				errorPage.waitForTitle(reasonPhrase));
+	}
+
+	// ---- Language switch ------------------------------------------------------
+
+	@When("user switches the error handler page language to {string}")
+	public void userSwitchesErrorHandlerLanguage(String lang) {
+		errorPage.switchLanguage(lang);
+	}
+
+	@Then("verify the error handler page displays title in {string} language")
+	public void verifyErrorTitleInLanguage(String lang) {
+		String expected = LocaleTextUtil.get(lang, TITLE_KEY);
+		assertTrue("Expected error title '" + expected + "' (" + lang + ") but was '" + errorPage.getErrorTitle() + "'",
+				errorPage.waitForTitle(expected));
+	}
+
+	@Then("verify the error handler page displays description in {string} language")
+	public void verifyErrorDescriptionInLanguage(String lang) {
+		String expected = LocaleTextUtil.get(lang, DETAIL_KEY);
+		assertTrue(
+				"Expected error description '" + expected + "' (" + lang + ") but was '"
+						+ errorPage.getErrorDescription() + "'",
+				errorPage.waitForDescription(expected));
+	}
+
+	// Higher order than BaseTest's @After (default 10000) so interception is
+	// released while the driver is still alive.
+	@After(value = "@errorHandlerHttp", order = 20000)
+	public void tearDownInterceptor() {
+		if (interceptor != null) {
+			interceptor.close();
+			interceptor = null;
+		}
+	}
+}

--- a/ui-test/src/main/java/stepdefinitions/ErrorHandlerStepDef.java
+++ b/ui-test/src/main/java/stepdefinitions/ErrorHandlerStepDef.java
@@ -13,22 +13,12 @@ import pages.ErrorHandlerPage;
 import utils.LocaleTextUtil;
 import utils.NetworkErrorInterceptor;
 
-/**
- * Steps for the "Something went wrong" error handler page.
- *
- * Two layers are covered:
- * - Generic page + language switch via direct navigation (runs everywhere).
- * - Real HTTP 4XX/5XX (400/403/404/405/415/500/502/503/504) forced through CDP
- *   interception (@localOnly), which drives the app's axios error interceptor
- *   into the error page carrying the status code, so the title renders the HTTP
- *   reason phrase.
- */
+// Steps for the "Something went wrong" error handler page
 public class ErrorHandlerStepDef {
 
 	private static final String TITLE_KEY = "something_went_wrong";
 	private static final String DETAIL_KEY = "something_went_wrong_detail";
-	// Only the /settings call goes through the app's ApiService response
-	// interceptor and is guaranteed on every page load (via the shared NavBar).
+	// Only /settings goes through the app's ApiService interceptor on every page load
 	private static final String SETTINGS_API = "/v1/signup/settings";
 
 	private final WebDriver driver;
@@ -91,8 +81,7 @@ public class ErrorHandlerStepDef {
 				errorPage.waitForDescription(expected));
 	}
 
-	// Higher order than BaseTest's @After (default 10000) so interception is
-	// released while the driver is still alive.
+	// Higher order than BaseTest's @After so interception is released while the driver is alive
 	@After(value = "@errorHandlerHttp", order = 20000)
 	public void tearDownInterceptor() {
 		if (interceptor != null) {

--- a/ui-test/src/main/java/stepdefinitions/ForgetPasswordStepDefinition.java
+++ b/ui-test/src/main/java/stepdefinitions/ForgetPasswordStepDefinition.java
@@ -48,9 +48,8 @@ public class ForgetPasswordStepDefinition {
 
 	@When("user enters the OTP")
 	public void userEnterOtp() {
-		String number = RegisteredDetails.getMobileNumber();
-		number = EsignetUtil.normalizeIdentifierForOtp(number);
-		forgetPasswordPage.enterOtp(NotificationListener.getOtp(number));
+		String otp = EsignetUtil.getVerifiedOtp(RegisteredDetails.getMobileNumber());
+		forgetPasswordPage.enterOtp(otp);
 	}
 
 	@When("user click on reset password button")

--- a/ui-test/src/main/java/stepdefinitions/LoginOptionsStepDefinition.java
+++ b/ui-test/src/main/java/stepdefinitions/LoginOptionsStepDefinition.java
@@ -18,7 +18,6 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import io.mosip.testrig.apirig.testrunner.OTPListener;
-import io.mosip.testrig.apirig.utils.NotificationListener;
 import pages.LoginOptionsPage;
 import pages.RegistrationPage;
 import utils.EsignetUtil;
@@ -69,8 +68,8 @@ public class LoginOptionsStepDefinition {
 
 	@When("user enters the correct OTP as input")
 	public void userEntersOtp() {
-		String mobile = EsignetUtil.normalizeIdentifierForOtp(RegisteredDetails.getMobileNumber());
-		registrationPage.enterOtp(NotificationListener.getOtp(mobile));
+		String otp = EsignetUtil.getVerifiedOtp(RegisteredDetails.getMobileNumber());
+		registrationPage.enterOtp(otp);
 	}
 
 	@And("user redirected to registration page")
@@ -432,6 +431,51 @@ public class LoginOptionsStepDefinition {
 	public void entersAlphaNumeric() {
 		String alphaNumeric = EsignetUtil.getAlphaNumeric();
 		loginOptionsPage.enterRegisteredMobileNumber(alphaNumeric);
+	}
+
+	// ---- Password language + login field ------------------------------------
+
+	private String lastLanguagePassword;
+
+	@When("user enters a valid format mobile number in the login mobile field")
+	public void userEntersValidFormatMobile() {
+		String number = EsignetUtil.generateMobileNumberFromRegex();
+		loginOptionsPage.enterRegisteredMobileNumber(number);
+	}
+
+	@When("user enters English and Khmer combined password into password field")
+	public void userEntersEngKhmerPassword() {
+		lastLanguagePassword = EsignetUtil.generateEngKhmerPassword();
+		loginOptionsPage.enterRegisteredPassword(lastLanguagePassword);
+	}
+
+	@When("user enters Khmer and numbers combined password into password field")
+	public void userEntersKhmerNumericPassword() {
+		lastLanguagePassword = EsignetUtil.generateKhmerNumericPassword();
+		loginOptionsPage.enterRegisteredPassword(lastLanguagePassword);
+	}
+
+	@When("user enters Hindi and English combined password into password field")
+	public void userEntersHindiEnglishPassword() {
+		lastLanguagePassword = EsignetUtil.generateHindiEnglishPassword();
+		loginOptionsPage.enterRegisteredPassword(lastLanguagePassword);
+	}
+
+	@Then("verify the password field is retained the entered value")
+	public void verifyPasswordFieldRetainsValue() {
+		String retained = loginOptionsPage.getEnteredPassword();
+		assertEquals("Password field should retain the multi-language input", lastLanguagePassword, retained);
+	}
+
+	@When("user enters a valid password into the password field")
+	public void userEntersValidPassword() {
+		String password = EsignetUtil.generateValidPasswordFromActuator();
+		loginOptionsPage.enterRegisteredPassword(password);
+	}
+
+	@Then("verify the login button is in disabled state")
+	public void verifyLoginButtonDisabledState() {
+		Assert.assertTrue(loginOptionsPage.isLoginButtonDisabled(), "Login button should be disabled");
 	}
 
 }

--- a/ui-test/src/main/java/stepdefinitions/SignUpStepDef.java
+++ b/ui-test/src/main/java/stepdefinitions/SignUpStepDef.java
@@ -357,8 +357,8 @@ public class SignUpStepDef {
 
 	@When("user enters the complete 6-digit OTP")
 	public void userEntersOtp() {
-		String number = EsignetUtil.normalizeIdentifierForOtp(lastGeneratedIdentifier);
-		registrationPage.enterOtp(NotificationListener.getOtp(number));
+		String otp = EsignetUtil.getVerifiedOtp(lastGeneratedIdentifier);
+		registrationPage.enterOtp(otp);
 	}
 
 	@Then("verify OTP is masked as soon as it is entered")

--- a/ui-test/src/main/java/stepdefinitions/SignupFormFieldStepDef.java
+++ b/ui-test/src/main/java/stepdefinitions/SignupFormFieldStepDef.java
@@ -8,16 +8,8 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import pages.SignupFormFieldPage;
 
-/**
- * Steps for the dynamically rendered Setup Account form fields - radio (gender),
- * textarea (details) and file upload (passport / photo). The Setup Account form
- * itself is reached through the existing registration-flow steps used as a
- * Background in the feature files.
- *
- * Scope note: in the esqa2 UI-spec these fields are optional (required=false),
- * so mandatory-validation / error-clearing cases (which need required=true) are
- * intentionally not covered here - they require a modified schema.
- */
+// Steps for the dynamically rendered Setup Account form fields - radio, textarea and file upload.
+// These fields are optional in the esqa2 UI-spec, so mandatory-validation cases are not covered here.
 public class SignupFormFieldStepDef {
 
 	private final WebDriver driver;

--- a/ui-test/src/main/java/stepdefinitions/SignupFormFieldStepDef.java
+++ b/ui-test/src/main/java/stepdefinitions/SignupFormFieldStepDef.java
@@ -1,0 +1,129 @@
+package stepdefinitions;
+
+import org.openqa.selenium.WebDriver;
+import org.testng.Assert;
+
+import base.BaseTest;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import pages.SignupFormFieldPage;
+
+/**
+ * Steps for the dynamically rendered Setup Account form fields - radio (gender),
+ * textarea (details) and file upload (passport / photo). The Setup Account form
+ * itself is reached through the existing registration-flow steps used as a
+ * Background in the feature files.
+ *
+ * Scope note: in the esqa2 UI-spec these fields are optional (required=false),
+ * so mandatory-validation / error-clearing cases (which need required=true) are
+ * intentionally not covered here - they require a modified schema.
+ */
+public class SignupFormFieldStepDef {
+
+	private final WebDriver driver;
+	private final SignupFormFieldPage formFieldPage;
+
+	private String lastEnteredText;
+
+	public SignupFormFieldStepDef(BaseTest baseTest) {
+		this.driver = BaseTest.getDriver();
+		this.formFieldPage = new SignupFormFieldPage(driver);
+	}
+
+	// ---- Radio ----------------------------------------------------------------
+
+	@Then("verify the {string} radio field is rendered with its label and options")
+	public void verifyRadioRendered(String fieldId) {
+		Assert.assertTrue(formFieldPage.isRadioFieldRendered(fieldId),
+				"Radio field '" + fieldId + "' should render its options");
+		Assert.assertTrue(formFieldPage.isRadioLabelRendered(fieldId),
+				"Radio field '" + fieldId + "' should render its label");
+	}
+
+	@When("user selects an option in the {string} radio field")
+	public void userSelectsRadioOption(String fieldId) {
+		formFieldPage.selectRadioOption(fieldId, 0);
+	}
+
+	@Then("verify one option is selected in the {string} radio field")
+	public void verifyOneRadioSelected(String fieldId) {
+		Assert.assertEquals(formFieldPage.getSelectedRadioCount(fieldId), 1,
+				"Exactly one option should be selected in '" + fieldId + "'");
+	}
+
+	@When("user selects two different options in the {string} radio field")
+	public void userSelectsTwoRadioOptions(String fieldId) {
+		int selected = formFieldPage.selectTwoOptionsAndCountSelected(fieldId);
+		Assert.assertEquals(selected, 1,
+				"Radio group '" + fieldId + "' must allow only a single selection at a time");
+	}
+
+	// ---- Textarea -------------------------------------------------------------
+
+	@Then("verify the {string} textarea field is rendered")
+	public void verifyTextareaRendered(String fieldId) {
+		Assert.assertTrue(formFieldPage.isTextareaRendered(fieldId),
+				"Textarea field '" + fieldId + "' should be rendered");
+	}
+
+	@Then("verify the {string} textarea has {int} default rows")
+	public void verifyTextareaDefaultRows(String fieldId, int expectedRows) {
+		Assert.assertEquals(formFieldPage.getTextareaRows(fieldId), expectedRows,
+				"Textarea '" + fieldId + "' should render with " + expectedRows + " rows by default");
+	}
+
+	@Then("verify the {string} textarea placeholder is rendered")
+	public void verifyTextareaPlaceholder(String fieldId) {
+		String placeholder = formFieldPage.getTextareaPlaceholder(fieldId);
+		Assert.assertNotNull(placeholder, "Textarea '" + fieldId + "' should have a placeholder");
+		Assert.assertFalse(placeholder.trim().isEmpty(),
+				"Textarea '" + fieldId + "' placeholder should not be empty");
+	}
+
+	@When("user enters text into the {string} textarea")
+	public void userEntersTextIntoTextarea(String fieldId) {
+		lastEnteredText = "Automation entered details 12345";
+		formFieldPage.enterTextarea(fieldId, lastEnteredText);
+	}
+
+	@Then("verify the {string} textarea retains the entered text")
+	public void verifyTextareaRetainsText(String fieldId) {
+		Assert.assertEquals(formFieldPage.getTextareaValue(fieldId), lastEnteredText,
+				"Textarea '" + fieldId + "' should retain the entered text");
+	}
+
+	// ---- File upload ----------------------------------------------------------
+
+	@Then("verify the {string} file upload field is rendered with its label")
+	public void verifyFileUploadRendered(String fieldId) {
+		Assert.assertTrue(formFieldPage.isFileUploadLabelRendered(fieldId),
+				"File upload field '" + fieldId + "' should render with its label");
+	}
+
+	@When("user uploads a supported document for the {string} field")
+	public void userUploadsSupportedFile(String fieldId) throws Exception {
+		if ("photo".equalsIgnoreCase(fieldId)) {
+			formFieldPage.uploadClasspathFile(fieldId, "config/Photo.jpg", "Photo.jpg");
+		} else {
+			formFieldPage.uploadClasspathFile(fieldId, "config/Passport.pdf", "Passport.pdf");
+		}
+	}
+
+	@Then("verify the supported file is accepted for the {string} field")
+	public void verifySupportedFileAccepted(String fieldId) {
+		formFieldPage.waitForFieldValid(fieldId);
+		Assert.assertFalse(formFieldPage.isUnsupportedFileErrorShown(fieldId),
+				"Supported file should be accepted without a validation error for '" + fieldId + "'");
+	}
+
+	@When("user uploads an unsupported file for the {string} field")
+	public void userUploadsUnsupportedFile(String fieldId) throws Exception {
+		formFieldPage.uploadUnsupportedFile(fieldId);
+	}
+
+	@Then("verify an unsupported file error is shown for the {string} field")
+	public void verifyUnsupportedFileError(String fieldId) {
+		Assert.assertTrue(formFieldPage.isUnsupportedFileErrorShown(fieldId),
+				"An unsupported file type should be rejected with an error for '" + fieldId + "'");
+	}
+}

--- a/ui-test/src/main/java/stepdefinitions/TransactionTimeoutStepDef.java
+++ b/ui-test/src/main/java/stepdefinitions/TransactionTimeoutStepDef.java
@@ -1,0 +1,108 @@
+package stepdefinitions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.openqa.selenium.WebDriver;
+
+import base.BaseTest;
+import io.cucumber.java.After;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import pages.TransactionTimeoutPopupPage;
+import utils.ForcedApiResponseInterceptor;
+import utils.LocaleTextUtil;
+
+/**
+ * Steps for "Setup account after the signup transaction has expired".
+ *
+ * <p>A real transaction expiry takes ~5 minutes ({@code mosip.signup.*.txn.timeout
+ * = 300s}); to keep the scenario fast the {@code /registration/verify-challenge}
+ * response is faked via CDP interception (@localOnly) to carry the backend's
+ * {@code invalid_transaction} error. The signup app treats that as a critical
+ * error and raises the {@code SignUpPopover} (title "Error!", the localized
+ * error message, and an "Okay" button) &mdash; exactly what a genuine expiry
+ * shows when the user clicks Verify OTP.
+ *
+ * <p>Text is asserted against the app's own locale files (via
+ * {@link LocaleTextUtil}) so it stays in sync with the UI. The popup message is
+ * {@code error_response.invalid_transaction}, which the app renders as "The
+ * request took too long to process. Please try again later." (the current
+ * wording for a timed-out transaction).
+ */
+public class TransactionTimeoutStepDef {
+
+	private static final String GENERATE_CHALLENGE_API = "/registration/generate-challenge";
+	private static final String VERIFY_CHALLENGE_API = "/registration/verify-challenge";
+	// generate-challenge is stubbed to succeed so the OTP screen is reached
+	// deterministically (no dependency on real SMS delivery / send-OTP rate limits),
+	// while verify-challenge returns the backend's expired-transaction error.
+	private static final String GENERATE_CHALLENGE_SUCCESS_BODY =
+			"{\"response\":{\"status\":\"SUCCESS\"},\"errors\":[]}";
+	private static final String INVALID_TRANSACTION_BODY =
+			"{\"response\":null,\"errors\":[{\"errorCode\":\"invalid_transaction\",\"errorMessage\":\"invalid transaction\"}]}";
+
+	private static final String TITLE_KEY = "error";
+	private static final String MESSAGE_KEY = "error_response.invalid_transaction";
+	private static final String OKAY_KEY = "okay";
+
+	private final WebDriver driver;
+	private final TransactionTimeoutPopupPage popupPage;
+	private ForcedApiResponseInterceptor interceptor;
+
+	public TransactionTimeoutStepDef(BaseTest baseTest) {
+		this.driver = BaseTest.getDriver();
+		this.popupPage = new TransactionTimeoutPopupPage(driver);
+	}
+
+	@Given("the signup transaction is forced to expire on OTP verification")
+	public void forceTransactionToExpireOnVerify() {
+		Map<String, String> stubs = new LinkedHashMap<>();
+		stubs.put(GENERATE_CHALLENGE_API, GENERATE_CHALLENGE_SUCCESS_BODY);
+		stubs.put(VERIFY_CHALLENGE_API, INVALID_TRANSACTION_BODY);
+		interceptor = new ForcedApiResponseInterceptor(driver, 200, stubs);
+	}
+
+	@Then("verify the transaction timeout error popup is displayed")
+	public void verifyTransactionTimeoutPopupDisplayed() {
+		assertTrue("Transaction timeout error popup was not displayed", popupPage.isPopupDisplayed());
+	}
+
+	@Then("verify the error popup header shows the error title")
+	public void verifyErrorPopupHeader() {
+		String expected = LocaleTextUtil.get(popupPage.getActiveLanguage(), TITLE_KEY);
+		assertEquals("Unexpected error popup title", expected, popupPage.getPopupTitle());
+	}
+
+	@Then("verify the error popup message shows the transaction timeout message")
+	public void verifyErrorPopupMessage() {
+		String expected = LocaleTextUtil.get(popupPage.getActiveLanguage(), MESSAGE_KEY);
+		assertEquals("Unexpected error popup message", expected, popupPage.getPopupMessage());
+	}
+
+	@Then("verify the error popup has an Okay button")
+	public void verifyOkayButton() {
+		assertTrue("Okay button not displayed on the error popup", popupPage.isOkayButtonDisplayed());
+		String expected = LocaleTextUtil.get(popupPage.getActiveLanguage(), OKAY_KEY);
+		assertEquals("Unexpected Okay button label", expected, popupPage.getOkayButtonText());
+	}
+
+	@When("user clicks on the Okay button in the error popup")
+	public void userClicksOkay() {
+		popupPage.clickOkay();
+	}
+
+	// Higher order than BaseTest's @After so interception is released while the
+	// driver is still alive (mirrors ErrorHandlerStepDef).
+	@After(value = "@transactionTimeout", order = 20000)
+	public void tearDownInterceptor() {
+		if (interceptor != null) {
+			interceptor.close();
+			interceptor = null;
+		}
+	}
+}

--- a/ui-test/src/main/java/stepdefinitions/TransactionTimeoutStepDef.java
+++ b/ui-test/src/main/java/stepdefinitions/TransactionTimeoutStepDef.java
@@ -17,30 +17,13 @@ import pages.TransactionTimeoutPopupPage;
 import utils.ForcedApiResponseInterceptor;
 import utils.LocaleTextUtil;
 
-/**
- * Steps for "Setup account after the signup transaction has expired".
- *
- * <p>A real transaction expiry takes ~5 minutes ({@code mosip.signup.*.txn.timeout
- * = 300s}); to keep the scenario fast the {@code /registration/verify-challenge}
- * response is faked via CDP interception (@localOnly) to carry the backend's
- * {@code invalid_transaction} error. The signup app treats that as a critical
- * error and raises the {@code SignUpPopover} (title "Error!", the localized
- * error message, and an "Okay" button) &mdash; exactly what a genuine expiry
- * shows when the user clicks Verify OTP.
- *
- * <p>Text is asserted against the app's own locale files (via
- * {@link LocaleTextUtil}) so it stays in sync with the UI. The popup message is
- * {@code error_response.invalid_transaction}, which the app renders as "The
- * request took too long to process. Please try again later." (the current
- * wording for a timed-out transaction).
- */
+// Steps for "Setup account after the signup transaction has expired".
+// A real expiry takes ~5 minutes, so verify-challenge is faked to return invalid_transaction instead.
 public class TransactionTimeoutStepDef {
 
 	private static final String GENERATE_CHALLENGE_API = "/registration/generate-challenge";
 	private static final String VERIFY_CHALLENGE_API = "/registration/verify-challenge";
-	// generate-challenge is stubbed to succeed so the OTP screen is reached
-	// deterministically (no dependency on real SMS delivery / send-OTP rate limits),
-	// while verify-challenge returns the backend's expired-transaction error.
+	// Stubbed to succeed so the OTP screen is reached without depending on real SMS delivery
 	private static final String GENERATE_CHALLENGE_SUCCESS_BODY =
 			"{\"response\":{\"status\":\"SUCCESS\"},\"errors\":[]}";
 	private static final String INVALID_TRANSACTION_BODY =
@@ -96,8 +79,7 @@ public class TransactionTimeoutStepDef {
 		popupPage.clickOkay();
 	}
 
-	// Higher order than BaseTest's @After so interception is released while the
-	// driver is still alive (mirrors ErrorHandlerStepDef).
+	// Higher order than BaseTest's @After so interception is released while the driver is alive
 	@After(value = "@transactionTimeout", order = 20000)
 	public void tearDownInterceptor() {
 		if (interceptor != null) {

--- a/ui-test/src/main/java/utils/EsignetUtil.java
+++ b/ui-test/src/main/java/utils/EsignetUtil.java
@@ -281,15 +281,10 @@ public class EsignetUtil extends AdminTestUtil {
 	}
 
 	// ---- Mixed-language passwords (login password-language tests) --------------
-	// These feed the eSignet login (relying-party) screen, whose accept/reject
-	// behaviour is governed by the oidc-ui client policy - not the signup policy
-	// that getPasswordPattern() reads from the signup actuator. There is therefore
-	// no policy assertion to make here that would be correct across environments,
-	// so PasswordLanguageLogin.feature asserts the reliably verifiable behaviour
-	// instead: the field accepts and retains the multi-language input.
+	// Accept/reject here is governed by the oidc-ui client policy, not the signup policy,
+	// so the feature asserts only that the field retains the multi-language input.
 
-	// Password material is generated with SecureRandom (not java.util.Random) to
-	// satisfy static analysis, even though these are throwaway test inputs.
+	// SecureRandom over java.util.Random to satisfy static analysis, though these are throwaway inputs
 	private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
 	private static String randomCharsInRange(int start, int end, int count) {
@@ -308,7 +303,6 @@ public class EsignetUtil extends AdminTestUtil {
 		return pwd.toString();
 	}
 
-	/** English letters combined with Khmer characters (plus baseline complexity). */
 	public static String generateEngKhmerPassword() {
 		StringBuilder pwd = new StringBuilder("Aa1@");
 		pwd.append(randomCharsInRange(0x1780, 0x17FF, 4));
@@ -316,7 +310,6 @@ public class EsignetUtil extends AdminTestUtil {
 		return padToMinLength(pwd, 'x');
 	}
 
-	/** Khmer characters combined with numbers. */
 	public static String generateKhmerNumericPassword() {
 		StringBuilder pwd = new StringBuilder();
 		pwd.append(randomCharsInRange(0x1780, 0x17FF, 4));
@@ -324,7 +317,7 @@ public class EsignetUtil extends AdminTestUtil {
 		return padToMinLength(pwd, '7');
 	}
 
-	/** Hindi (Devanagari) characters combined with English - unsupported language. */
+	// Devanagari is an unsupported language for this deployment
 	public static String generateHindiEnglishPassword() {
 		StringBuilder pwd = new StringBuilder("Ab1@");
 		pwd.append(randomCharsInRange(0x0900, 0x097F, 4));
@@ -776,18 +769,7 @@ public class EsignetUtil extends AdminTestUtil {
 				"mosip.signup.identifier.prefix");
 	}
 
-	/**
-	 * Returns the OTP delivered to {@code identifier}, failing the scenario if none
-	 * arrives.
-	 *
-	 * <p>Normalising the identifier, waiting for delivery and asserting the result
-	 * are kept together because every caller needs all three: a change to the wait,
-	 * the retry behaviour or the failure message is then a single edit here rather
-	 * than the same edit repeated in each step definition.
-	 *
-	 * @param identifier the number the OTP was sent to, prefixed or unprefixed
-	 * @return the delivered OTP, trimmed and guaranteed non-empty
-	 */
+	// Normalise, wait and assert are kept together since every caller needs all three
 	public static String getVerifiedOtp(String identifier) {
 		String number = normalizeIdentifierForOtp(identifier);
 		String otp = waitForDeliveredOtp(number);
@@ -818,11 +800,7 @@ public class EsignetUtil extends AdminTestUtil {
 		return number;
 	}
 
-	// NotificationListener.getOtp() already blocks and self-polls the queue for the
-	// full OTP-expiry window, returning the moment the OTP is delivered. A single call
-	// therefore already tolerates delivery lag - looping over it only multiplies the
-	// worst-case wait (3x the OTP-expiry window) when the OTP never arrives, and any
-	// OTP that lands after that window has already expired and is useless anyway.
+	// getOtp() already blocks for the full OTP-expiry window, so looping over it only multiplies the wait
 	private static String waitForDeliveredOtp(String mobile) {
 		String otp = NotificationListener.getOtp(mobile);
 		return otp == null ? "" : otp.trim();

--- a/ui-test/src/main/java/utils/EsignetUtil.java
+++ b/ui-test/src/main/java/utils/EsignetUtil.java
@@ -1,5 +1,6 @@
 package utils;
 
+import java.security.SecureRandom;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
@@ -17,11 +18,13 @@ import org.apache.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.testng.Assert;
 
 import javax.ws.rs.core.MediaType;
 
 import io.mosip.testrig.apirig.utils.AdminTestUtil;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
+import io.mosip.testrig.apirig.utils.NotificationListener;
 import io.mosip.testrig.apirig.utils.RestClient;
 import io.restassured.response.Response;
 import constants.UiConstants;
@@ -275,6 +278,58 @@ public class EsignetUtil extends AdminTestUtil {
 			pwd.append(all.charAt(random.nextInt(all.length())));
 		}
 		return pwd.toString();
+	}
+
+	// ---- Mixed-language passwords (login password-language tests) --------------
+	// These feed the eSignet login (relying-party) screen, whose accept/reject
+	// behaviour is governed by the oidc-ui client policy - not the signup policy
+	// that getPasswordPattern() reads from the signup actuator. There is therefore
+	// no policy assertion to make here that would be correct across environments,
+	// so PasswordLanguageLogin.feature asserts the reliably verifiable behaviour
+	// instead: the field accepts and retains the multi-language input.
+
+	// Password material is generated with SecureRandom (not java.util.Random) to
+	// satisfy static analysis, even though these are throwaway test inputs.
+	private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+	private static String randomCharsInRange(int start, int end, int count) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < count; i++) {
+			sb.append((char) (start + SECURE_RANDOM.nextInt(end - start + 1)));
+		}
+		return sb.toString();
+	}
+
+	private static String padToMinLength(StringBuilder pwd, char filler) {
+		int min = getPasswordMinLength();
+		while (pwd.length() < min) {
+			pwd.append(filler);
+		}
+		return pwd.toString();
+	}
+
+	/** English letters combined with Khmer characters (plus baseline complexity). */
+	public static String generateEngKhmerPassword() {
+		StringBuilder pwd = new StringBuilder("Aa1@");
+		pwd.append(randomCharsInRange(0x1780, 0x17FF, 4));
+		pwd.append("bc");
+		return padToMinLength(pwd, 'x');
+	}
+
+	/** Khmer characters combined with numbers. */
+	public static String generateKhmerNumericPassword() {
+		StringBuilder pwd = new StringBuilder();
+		pwd.append(randomCharsInRange(0x1780, 0x17FF, 4));
+		pwd.append("12345");
+		return padToMinLength(pwd, '7');
+	}
+
+	/** Hindi (Devanagari) characters combined with English - unsupported language. */
+	public static String generateHindiEnglishPassword() {
+		StringBuilder pwd = new StringBuilder("Ab1@");
+		pwd.append(randomCharsInRange(0x0900, 0x097F, 4));
+		pwd.append("xy");
+		return padToMinLength(pwd, 'z');
 	}
 
 	private static JSONObject signupUISpecResponse;
@@ -661,7 +716,7 @@ public class EsignetUtil extends AdminTestUtil {
 			value.append(chars.charAt(random.nextInt(chars.length())));
 		}
 
-		if (regex.contains("(?!0)") && value.charAt(0) == '0') {
+		if (regex.contains("(?!0)") && value.length() > 0 && value.charAt(0) == '0') {
 			value.setCharAt(0, (char) ('1' + random.nextInt(9)));
 		}
 
@@ -721,7 +776,26 @@ public class EsignetUtil extends AdminTestUtil {
 				"mosip.signup.identifier.prefix");
 	}
 
-	public static String normalizeIdentifierForOtp(String number) {
+	/**
+	 * Returns the OTP delivered to {@code identifier}, failing the scenario if none
+	 * arrives.
+	 *
+	 * <p>Normalising the identifier, waiting for delivery and asserting the result
+	 * are kept together because every caller needs all three: a change to the wait,
+	 * the retry behaviour or the failure message is then a single edit here rather
+	 * than the same edit repeated in each step definition.
+	 *
+	 * @param identifier the number the OTP was sent to, prefixed or unprefixed
+	 * @return the delivered OTP, trimmed and guaranteed non-empty
+	 */
+	public static String getVerifiedOtp(String identifier) {
+		String number = normalizeIdentifierForOtp(identifier);
+		String otp = waitForDeliveredOtp(number);
+		Assert.assertTrue(otp != null && !otp.trim().isEmpty(), "OTP was not delivered for: " + number);
+		return otp.trim();
+	}
+
+	private static String normalizeIdentifierForOtp(String number) {
 		boolean removeCode = Boolean.parseBoolean(getRemoveCountryCode());
 		String prefix = getIdentifierPrefix();
 		if (prefix == null) {
@@ -742,6 +816,16 @@ public class EsignetUtil extends AdminTestUtil {
 		}
 
 		return number;
+	}
+
+	// NotificationListener.getOtp() already blocks and self-polls the queue for the
+	// full OTP-expiry window, returning the moment the OTP is delivered. A single call
+	// therefore already tolerates delivery lag - looping over it only multiplies the
+	// worst-case wait (3x the OTP-expiry window) when the OTP never arrives, and any
+	// OTP that lands after that window has already expired and is useless anyway.
+	private static String waitForDeliveredOtp(String mobile) {
+		String otp = NotificationListener.getOtp(mobile);
+		return otp == null ? "" : otp.trim();
 	}
 
 	public static String getMandatoryLanguage() {

--- a/ui-test/src/main/java/utils/ForcedApiResponseInterceptor.java
+++ b/ui-test/src/main/java/utils/ForcedApiResponseInterceptor.java
@@ -9,46 +9,19 @@ import org.openqa.selenium.remote.http.Contents;
 import org.openqa.selenium.remote.http.HttpResponse;
 import org.openqa.selenium.remote.http.Route;
 
-/**
- * Forces a fixed HTTP status code and JSON body on backend calls whose URL
- * contains a configurable substring, using Selenium's CDP
- * {@link NetworkInterceptor}.
- *
- * <p>Unlike {@link NetworkErrorInterceptor} (which fakes a raw HTTP <em>error</em>
- * status with a generic body), this returns a caller-supplied JSON payload,
- * defaulting to HTTP 200, so application-level error envelopes can be simulated
- * &mdash; e.g. a signup {@code verify-challenge} response carrying
- * {@code {"errors":[{"errorCode":"invalid_transaction"}]}} to drive the
- * transaction-timeout popup without waiting for the real (~5 minute) expiry.
- *
- * <p>CDP-only: works with a local ChromeDriver, NOT BrowserStack
- * RemoteWebDriver, so scenarios relying on it must be tagged {@code @localOnly}.
- */
+// Forces a fixed status code and JSON body on backend calls matching a URL substring.
+// CDP-only, so scenarios using it must be tagged @localOnly (no BrowserStack RemoteWebDriver).
 public class ForcedApiResponseInterceptor implements AutoCloseable {
 
 	private static final Logger logger = Logger.getLogger(ForcedApiResponseInterceptor.class);
 
 	private final NetworkInterceptor interceptor;
 
-	/**
-	 * @param driver       CDP-capable driver (ChromeDriver)
-	 * @param uriSubstring only requests whose URI contains this substring are faulted
-	 * @param statusCode   the HTTP status code to return for matching requests
-	 * @param jsonBody     the JSON response body to return for matching requests
-	 */
 	public ForcedApiResponseInterceptor(WebDriver driver, String uriSubstring, int statusCode, String jsonBody) {
 		this(driver, statusCode, Map.of(uriSubstring, jsonBody));
 	}
 
-	/**
-	 * Stubs several endpoints in a single CDP session. Two separate
-	 * {@link NetworkInterceptor} instances on the same driver would clash (the
-	 * last {@code Fetch.enable} wins), so all rules are combined into one route.
-	 *
-	 * @param driver                    CDP-capable driver (ChromeDriver)
-	 * @param statusCode                the HTTP status to return for every matched request
-	 * @param uriSubstringToJsonBody    map of URI substring -&gt; JSON response body
-	 */
+	// All rules share one route: two interceptors on the same driver clash, as the last Fetch.enable wins
 	public ForcedApiResponseInterceptor(WebDriver driver, int statusCode, Map<String, String> uriSubstringToJsonBody) {
 		Route route = null;
 		for (Map.Entry<String, String> rule : uriSubstringToJsonBody.entrySet()) {

--- a/ui-test/src/main/java/utils/ForcedApiResponseInterceptor.java
+++ b/ui-test/src/main/java/utils/ForcedApiResponseInterceptor.java
@@ -1,0 +1,78 @@
+package utils;
+
+import java.util.Map;
+
+import org.apache.log4j.Logger;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.devtools.NetworkInterceptor;
+import org.openqa.selenium.remote.http.Contents;
+import org.openqa.selenium.remote.http.HttpResponse;
+import org.openqa.selenium.remote.http.Route;
+
+/**
+ * Forces a fixed HTTP status code and JSON body on backend calls whose URL
+ * contains a configurable substring, using Selenium's CDP
+ * {@link NetworkInterceptor}.
+ *
+ * <p>Unlike {@link NetworkErrorInterceptor} (which fakes a raw HTTP <em>error</em>
+ * status with a generic body), this returns a caller-supplied JSON payload,
+ * defaulting to HTTP 200, so application-level error envelopes can be simulated
+ * &mdash; e.g. a signup {@code verify-challenge} response carrying
+ * {@code {"errors":[{"errorCode":"invalid_transaction"}]}} to drive the
+ * transaction-timeout popup without waiting for the real (~5 minute) expiry.
+ *
+ * <p>CDP-only: works with a local ChromeDriver, NOT BrowserStack
+ * RemoteWebDriver, so scenarios relying on it must be tagged {@code @localOnly}.
+ */
+public class ForcedApiResponseInterceptor implements AutoCloseable {
+
+	private static final Logger logger = Logger.getLogger(ForcedApiResponseInterceptor.class);
+
+	private final NetworkInterceptor interceptor;
+
+	/**
+	 * @param driver       CDP-capable driver (ChromeDriver)
+	 * @param uriSubstring only requests whose URI contains this substring are faulted
+	 * @param statusCode   the HTTP status code to return for matching requests
+	 * @param jsonBody     the JSON response body to return for matching requests
+	 */
+	public ForcedApiResponseInterceptor(WebDriver driver, String uriSubstring, int statusCode, String jsonBody) {
+		this(driver, statusCode, Map.of(uriSubstring, jsonBody));
+	}
+
+	/**
+	 * Stubs several endpoints in a single CDP session. Two separate
+	 * {@link NetworkInterceptor} instances on the same driver would clash (the
+	 * last {@code Fetch.enable} wins), so all rules are combined into one route.
+	 *
+	 * @param driver                    CDP-capable driver (ChromeDriver)
+	 * @param statusCode                the HTTP status to return for every matched request
+	 * @param uriSubstringToJsonBody    map of URI substring -&gt; JSON response body
+	 */
+	public ForcedApiResponseInterceptor(WebDriver driver, int statusCode, Map<String, String> uriSubstringToJsonBody) {
+		Route route = null;
+		for (Map.Entry<String, String> rule : uriSubstringToJsonBody.entrySet()) {
+			final String uriSubstring = rule.getKey();
+			final String jsonBody = rule.getValue();
+			Route matched = Route.matching(req -> req.getUri().contains(uriSubstring))
+					.to(() -> req -> new HttpResponse()
+							.setStatus(statusCode)
+							.addHeader("Content-Type", "application/json")
+							.setContent(Contents.utf8String(jsonBody)));
+			route = (route == null) ? matched : Route.combine(route, matched);
+		}
+		this.interceptor = new NetworkInterceptor(driver, route);
+		logger.info("Forced API responses active: HTTP " + statusCode + " for " + uriSubstringToJsonBody.keySet());
+	}
+
+	@Override
+	public void close() {
+		try {
+			if (interceptor != null) {
+				interceptor.close();
+			}
+		} catch (Exception e) {
+			logger.warn("Failed to close forced API response interceptor: " + e.getMessage());
+		}
+	}
+}

--- a/ui-test/src/main/java/utils/LocaleTextUtil.java
+++ b/ui-test/src/main/java/utils/LocaleTextUtil.java
@@ -43,6 +43,11 @@ public class LocaleTextUtil {
 			throw new RuntimeException(
 					"Locale key '" + key + "' not found in '" + twoLetterLang + "' locale file");
 		}
+		if (!value.isTextual()) {
+			throw new RuntimeException("Locale key '" + key + "' in '" + twoLetterLang
+					+ "' locale file is not a text value but " + value.getNodeType()
+					+ ", so it holds no translation to assert against");
+		}
 		return value.asText();
 	}
 

--- a/ui-test/src/main/java/utils/LocaleTextUtil.java
+++ b/ui-test/src/main/java/utils/LocaleTextUtil.java
@@ -13,11 +13,7 @@ import org.apache.log4j.Logger;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-/**
- * Reads localized UI strings straight from the signup portal locale files
- * ({portalUrl}/locales/{lang}.json), so text assertions stay in sync with the
- * application copy instead of being hard-coded in tests.
- */
+// Reads localized strings from the portal's own locale files, so assertions stay in sync with the app copy
 public class LocaleTextUtil {
 
 	private static final Logger logger = Logger.getLogger(LocaleTextUtil.class);
@@ -27,13 +23,7 @@ public class LocaleTextUtil {
 	private LocaleTextUtil() {
 	}
 
-	/**
-	 * @param twoLetterLang locale file name without extension, e.g. "en" / "km"
-	 * @param key           translation key. Supports nested keys using dot
-	 *                      notation, e.g. "something_went_wrong" or
-	 *                      "error_response.invalid_transaction"
-	 * @return the translated value for the given key and language
-	 */
+	// Nested keys use dot notation, e.g. "error_response.invalid_transaction"
 	public static String get(String twoLetterLang, String key) {
 		JsonNode value = load(twoLetterLang);
 		for (String part : key.split("\\.")) {

--- a/ui-test/src/main/java/utils/LocaleTextUtil.java
+++ b/ui-test/src/main/java/utils/LocaleTextUtil.java
@@ -1,0 +1,74 @@
+package utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.log4j.Logger;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Reads localized UI strings straight from the signup portal locale files
+ * ({portalUrl}/locales/{lang}.json), so text assertions stay in sync with the
+ * application copy instead of being hard-coded in tests.
+ */
+public class LocaleTextUtil {
+
+	private static final Logger logger = Logger.getLogger(LocaleTextUtil.class);
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+	private static final Map<String, JsonNode> cache = new HashMap<>();
+
+	private LocaleTextUtil() {
+	}
+
+	/**
+	 * @param twoLetterLang locale file name without extension, e.g. "en" / "km"
+	 * @param key           translation key. Supports nested keys using dot
+	 *                      notation, e.g. "something_went_wrong" or
+	 *                      "error_response.invalid_transaction"
+	 * @return the translated value for the given key and language
+	 */
+	public static String get(String twoLetterLang, String key) {
+		JsonNode value = load(twoLetterLang);
+		for (String part : key.split("\\.")) {
+			value = (value == null) ? null : value.get(part);
+		}
+		if (value == null || value.isMissingNode()) {
+			throw new RuntimeException(
+					"Locale key '" + key + "' not found in '" + twoLetterLang + "' locale file");
+		}
+		return value.asText();
+	}
+
+	private static synchronized JsonNode load(String lang) {
+		if (cache.containsKey(lang)) {
+			return cache.get(lang);
+		}
+		String base = EsignetConfigManager.getSignupPortalUrl();
+		if (!base.endsWith("/")) {
+			base = base + "/";
+		}
+		String url = base + "locales/" + lang + ".json";
+		int timeoutMs = EsignetConfigManager.getTimeout() * 1000;
+		try {
+			URLConnection conn = URI.create(url).toURL().openConnection();
+			conn.setConnectTimeout(timeoutMs);
+			conn.setReadTimeout(timeoutMs);
+			try (InputStream in = conn.getInputStream()) {
+				String json = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+				JsonNode node = MAPPER.readTree(json);
+				cache.put(lang, node);
+				return node;
+			}
+		} catch (IOException e) {
+			logger.error("Failed to load locale file: " + url, e);
+			throw new RuntimeException("Failed to load locale file: " + url, e);
+		}
+	}
+}

--- a/ui-test/src/main/java/utils/NetworkErrorInterceptor.java
+++ b/ui-test/src/main/java/utils/NetworkErrorInterceptor.java
@@ -7,25 +7,14 @@ import org.openqa.selenium.remote.http.Contents;
 import org.openqa.selenium.remote.http.HttpResponse;
 import org.openqa.selenium.remote.http.Route;
 
-/**
- * Forces a given HTTP status code on backend calls whose URL contains a
- * configurable substring, using Selenium's CDP {@link NetworkInterceptor}.
- *
- * <p>This only works with a CDP-capable local driver (e.g. ChromeDriver). It is
- * NOT supported on BrowserStack RemoteWebDriver, so scenarios relying on it must
- * be tagged {@code @localOnly} and skipped when {@code runOnBrowserStack=true}.
- */
+// Forces a given HTTP status code on backend calls matching a URL substring.
+// CDP-only, so scenarios using it must be tagged @localOnly (no BrowserStack RemoteWebDriver).
 public class NetworkErrorInterceptor implements AutoCloseable {
 
 	private static final Logger logger = Logger.getLogger(NetworkErrorInterceptor.class);
 
 	private final NetworkInterceptor interceptor;
 
-	/**
-	 * @param driver       CDP-capable driver (ChromeDriver)
-	 * @param uriSubstring only requests whose URI contains this substring are faulted
-	 * @param statusCode   the HTTP status code to return for matching requests
-	 */
 	public NetworkErrorInterceptor(WebDriver driver, String uriSubstring, int statusCode) {
 		this.interceptor = new NetworkInterceptor(driver,
 				Route.matching(req -> req.getUri().contains(uriSubstring))

--- a/ui-test/src/main/java/utils/NetworkErrorInterceptor.java
+++ b/ui-test/src/main/java/utils/NetworkErrorInterceptor.java
@@ -1,0 +1,49 @@
+package utils;
+
+import org.apache.log4j.Logger;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.devtools.NetworkInterceptor;
+import org.openqa.selenium.remote.http.Contents;
+import org.openqa.selenium.remote.http.HttpResponse;
+import org.openqa.selenium.remote.http.Route;
+
+/**
+ * Forces a given HTTP status code on backend calls whose URL contains a
+ * configurable substring, using Selenium's CDP {@link NetworkInterceptor}.
+ *
+ * <p>This only works with a CDP-capable local driver (e.g. ChromeDriver). It is
+ * NOT supported on BrowserStack RemoteWebDriver, so scenarios relying on it must
+ * be tagged {@code @localOnly} and skipped when {@code runOnBrowserStack=true}.
+ */
+public class NetworkErrorInterceptor implements AutoCloseable {
+
+	private static final Logger logger = Logger.getLogger(NetworkErrorInterceptor.class);
+
+	private final NetworkInterceptor interceptor;
+
+	/**
+	 * @param driver       CDP-capable driver (ChromeDriver)
+	 * @param uriSubstring only requests whose URI contains this substring are faulted
+	 * @param statusCode   the HTTP status code to return for matching requests
+	 */
+	public NetworkErrorInterceptor(WebDriver driver, String uriSubstring, int statusCode) {
+		this.interceptor = new NetworkInterceptor(driver,
+				Route.matching(req -> req.getUri().contains(uriSubstring))
+						.to(() -> req -> new HttpResponse()
+								.setStatus(statusCode)
+								.addHeader("Content-Type", "application/json")
+								.setContent(Contents.utf8String("{\"error\":\"forced-" + statusCode + "\"}"))));
+		logger.info("Network interception active: '" + uriSubstring + "' -> HTTP " + statusCode);
+	}
+
+	@Override
+	public void close() {
+		try {
+			if (interceptor != null) {
+				interceptor.close();
+			}
+		} catch (Exception e) {
+			logger.warn("Failed to close network interceptor: " + e.getMessage());
+		}
+	}
+}

--- a/ui-test/src/main/java/utils/WaitUtil.java
+++ b/ui-test/src/main/java/utils/WaitUtil.java
@@ -26,20 +26,12 @@ public class WaitUtil {
 		wait.until(ExpectedConditions.elementToBeClickable(element));
 	}
 
-	/**
-	 * Resolves a locator once the element behind it is clickable. Throws
-	 * {@link org.openqa.selenium.TimeoutException} (not NoSuchElementException) when
-	 * it never becomes clickable, so callers can retry on a single exception type.
-	 */
+	// Throws TimeoutException rather than NoSuchElementException, so callers retry on one exception type
 	public static WebElement waitForClickability(WebDriver driver, By locator) {
 		return waitForClickability(driver, locator, Duration.ofSeconds(TIMEOUT));
 	}
 
-	/**
-	 * As {@link #waitForClickability(WebDriver, By)}, but with an explicit budget -
-	 * for callers that retry and so want each attempt to wait a fraction of the
-	 * configured timeout rather than all of it.
-	 */
+	// Explicit budget, for retrying callers that want each attempt to wait a fraction of the timeout
 	public static WebElement waitForClickability(WebDriver driver, By locator, Duration timeout) {
 		WebDriverWait wait = new WebDriverWait(driver, timeout);
 		return wait.until(ExpectedConditions.elementToBeClickable(locator));

--- a/ui-test/src/main/java/utils/WaitUtil.java
+++ b/ui-test/src/main/java/utils/WaitUtil.java
@@ -1,5 +1,6 @@
 package utils;
 
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -15,9 +16,33 @@ public class WaitUtil {
 		wait.until(ExpectedConditions.visibilityOf(element));
 	}
 
+	public static WebElement waitForVisibility(WebDriver driver, By locator) {
+		WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(TIMEOUT));
+		return wait.until(ExpectedConditions.visibilityOfElementLocated(locator));
+	}
+
 	public static void waitForClickability(WebDriver driver, WebElement element) {
 		WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(TIMEOUT));
 		wait.until(ExpectedConditions.elementToBeClickable(element));
+	}
+
+	/**
+	 * Resolves a locator once the element behind it is clickable. Throws
+	 * {@link org.openqa.selenium.TimeoutException} (not NoSuchElementException) when
+	 * it never becomes clickable, so callers can retry on a single exception type.
+	 */
+	public static WebElement waitForClickability(WebDriver driver, By locator) {
+		return waitForClickability(driver, locator, Duration.ofSeconds(TIMEOUT));
+	}
+
+	/**
+	 * As {@link #waitForClickability(WebDriver, By)}, but with an explicit budget -
+	 * for callers that retry and so want each attempt to wait a fraction of the
+	 * configured timeout rather than all of it.
+	 */
+	public static WebElement waitForClickability(WebDriver driver, By locator, Duration timeout) {
+		WebDriverWait wait = new WebDriverWait(driver, timeout);
+		return wait.until(ExpectedConditions.elementToBeClickable(locator));
 	}
 
 	public static boolean waitForInvisibility(WebDriver driver, WebElement element) {

--- a/ui-test/src/main/resources/config.properties
+++ b/ui-test/src/main/resources/config.properties
@@ -1,6 +1,6 @@
 # url
-baseurl =
-signup.portal.url =
+baseurl = 
+signup.portal.url = 
 actuatorSignupEndpoint =
 uiSpecEndpoint =
 
@@ -30,8 +30,8 @@ headless=true
 mobileEmulation=false
 mobileDevice=Pixel 5
 explicitWaitTimeout=
-keycloak-external-url =
-mosip_components_base_urls =
+keycloak-external-url = 
+mosip_components_base_urls = 
 enableDebug=no
 
 # ChromeDriver path used when running inside Docker on Linux

--- a/ui-test/src/main/resources/config.properties
+++ b/ui-test/src/main/resources/config.properties
@@ -1,6 +1,6 @@
 # url
-baseurl = 
-signup.portal.url = 
+baseurl =
+signup.portal.url =
 actuatorSignupEndpoint =
 uiSpecEndpoint =
 
@@ -30,8 +30,8 @@ headless=true
 mobileEmulation=false
 mobileDevice=Pixel 5
 explicitWaitTimeout=
-keycloak-external-url = 
-mosip_components_base_urls = 
+keycloak-external-url =
+mosip_components_base_urls =
 enableDebug=no
 
 # ChromeDriver path used when running inside Docker on Linux

--- a/ui-test/src/main/resources/featurefiles/ErrorHandler.feature
+++ b/ui-test/src/main/resources/featurefiles/ErrorHandler.feature
@@ -2,10 +2,7 @@ Feature: Esignet Error Handler Page
   Verifying the "Something went wrong" error handler page shown for HTTP 5XX
   backend responses, and that its content is localized on language switch.
 
-  # Runs everywhere (incl. BrowserStack). Loads the error route directly, so no
-  # HTTP status code is present in router state and both the title and the
-  # description come from the localized keys (something_went_wrong /
-  # something_went_wrong_detail). Language switch must update both lines.
+  # Loads the error route directly, so title and description both come from the localized keys
   @smoke @errorHandlerPage
   Scenario: Verify the error handler page content and language switch
     Given user navigates directly to the error handler page
@@ -16,14 +13,7 @@ Feature: Esignet Error Handler Page
     Then verify the error handler page displays title in "km" language
     And verify the error handler page displays description in "km" language
 
-  # High-fidelity, local Chrome only (@localOnly is skipped on BrowserStack).
-  # A real 4XX/5XX is forced on the /settings API via CDP so the app's axios
-  # interceptor redirects to the error page WITH the status code; the title then
-  # renders the HTTP reason phrase (e.g. Bad Request / Not Found / Internal Server
-  # Error) which is NOT localized, while only the description changes on language
-  # switch. The single outline reuses the same steps for every handled status
-  # code (see api.service.ts: [400, 403, 404, 405, 415, 500, 502, 503, 504]).
-
+  # Status code reaches the error page, so the title is the HTTP reason phrase and stays unlocalized
   @errorHandlerHttp @localOnly
   Scenario Outline: Verify the error handler page for HTTP <code> response and language switch
     Given the signup settings API is forced to return HTTP <code>

--- a/ui-test/src/main/resources/featurefiles/ErrorHandler.feature
+++ b/ui-test/src/main/resources/featurefiles/ErrorHandler.feature
@@ -1,0 +1,49 @@
+Feature: Esignet Error Handler Page
+  Verifying the "Something went wrong" error handler page shown for HTTP 5XX
+  backend responses, and that its content is localized on language switch.
+
+  # Runs everywhere (incl. BrowserStack). Loads the error route directly, so no
+  # HTTP status code is present in router state and both the title and the
+  # description come from the localized keys (something_went_wrong /
+  # something_went_wrong_detail). Language switch must update both lines.
+  @smoke @errorHandlerPage
+  Scenario: Verify the error handler page content and language switch
+    Given user navigates directly to the error handler page
+    When user switches the error handler page language to "en"
+    Then verify the error handler page displays title in "en" language
+    And verify the error handler page displays description in "en" language
+    When user switches the error handler page language to "km"
+    Then verify the error handler page displays title in "km" language
+    And verify the error handler page displays description in "km" language
+
+  # High-fidelity, local Chrome only (@localOnly is skipped on BrowserStack).
+  # A real 4XX/5XX is forced on the /settings API via CDP so the app's axios
+  # interceptor redirects to the error page WITH the status code; the title then
+  # renders the HTTP reason phrase (e.g. Bad Request / Not Found / Internal Server
+  # Error) which is NOT localized, while only the description changes on language
+  # switch. The single outline reuses the same steps for every handled status
+  # code (see api.service.ts: [400, 403, 404, 405, 415, 500, 502, 503, 504]).
+
+  @errorHandlerHttp @localOnly
+  Scenario Outline: Verify the error handler page for HTTP <code> response and language switch
+    Given the signup settings API is forced to return HTTP <code>
+    When user navigates to the signup portal to trigger the error
+    Then verify the error handler page title shows the reason phrase "<reasonPhrase>"
+    When user switches the error handler page language to "en"
+    Then verify the error handler page displays description in "en" language
+    And verify the error handler page title shows the reason phrase "<reasonPhrase>"
+    When user switches the error handler page language to "km"
+    Then verify the error handler page displays description in "km" language
+    And verify the error handler page title shows the reason phrase "<reasonPhrase>"
+
+    Examples:
+      | code | reasonPhrase           |
+      | 400  | Bad Request            |
+      | 403  | Forbidden              |
+      | 404  | Not Found              |
+      | 405  | Method Not Allowed     |
+      | 415  | Unsupported Media Type |
+      | 500  | Internal Server Error  |
+      | 502  | Bad Gateway            |
+      | 503  | Service Unavailable    |
+      | 504  | Gateway Timeout        |

--- a/ui-test/src/main/resources/featurefiles/PasswordLanguageLogin.feature
+++ b/ui-test/src/main/resources/featurefiles/PasswordLanguageLogin.feature
@@ -1,0 +1,42 @@
+Feature: Esignet Login - Password language and username field
+  Verifying the login (relying-party) password field accepts multi-language
+  passwords and the login button state.
+
+  # The password field's accept/reject behaviour on the eSignet login screen is
+  # governed by the oidc-ui client policy (not this repo's signup policy), so we
+  # assert the reliably verifiable behaviour: the field accepts and retains the
+  # multi-language input the user types.
+
+  @regression @passwordLanguage
+  Scenario: Enter password as a combination of English and Khmer
+    Given click on Sign In with eSignet
+    And user clicks on login with password button
+    When user enters a valid format mobile number in the login mobile field
+    And user enters English and Khmer combined password into password field
+    And user tabout of password field
+    Then verify the password field is retained the entered value
+
+  @regression @passwordLanguage
+  Scenario: Enter password as a combination of Khmer and numbers
+    Given click on Sign In with eSignet
+    And user clicks on login with password button
+    When user enters a valid format mobile number in the login mobile field
+    And user enters Khmer and numbers combined password into password field
+    And user tabout of password field
+    Then verify the password field is retained the entered value
+
+  @regression @passwordLanguage
+  Scenario: Enter password as a combination of an unsupported language (Hindi) and English
+    Given click on Sign In with eSignet
+    And user clicks on login with password button
+    When user enters a valid format mobile number in the login mobile field
+    And user enters Hindi and English combined password into password field
+    And user tabout of password field
+    Then verify the password field is retained the entered value
+
+  @regression @loginButtonState
+  Scenario: Login button stays disabled when only the password is filled
+    Given click on Sign In with eSignet
+    And user clicks on login with password button
+    When user enters a valid password into the password field
+    Then verify the login button is in disabled state

--- a/ui-test/src/main/resources/featurefiles/PasswordLanguageLogin.feature
+++ b/ui-test/src/main/resources/featurefiles/PasswordLanguageLogin.feature
@@ -2,11 +2,7 @@ Feature: Esignet Login - Password language and username field
   Verifying the login (relying-party) password field accepts multi-language
   passwords and the login button state.
 
-  # The password field's accept/reject behaviour on the eSignet login screen is
-  # governed by the oidc-ui client policy (not this repo's signup policy), so we
-  # assert the reliably verifiable behaviour: the field accepts and retains the
-  # multi-language input the user types.
-
+  # Accept/reject is governed by the oidc-ui client policy, so only retention is asserted
   @regression @passwordLanguage
   Scenario: Enter password as a combination of English and Khmer
     Given click on Sign In with eSignet

--- a/ui-test/src/main/resources/featurefiles/SignupDynamicFormFields.feature
+++ b/ui-test/src/main/resources/featurefiles/SignupDynamicFormFields.feature
@@ -3,11 +3,7 @@ Feature: Esignet Signup - Dynamic Setup Account form fields
   on the Setup Account form from the deployed UI-spec (esqa2: gender, details,
   passport, photo).
 
-  # These fields are optional (required=false) in the esqa2 spec, so only
-  # rendering and input behaviour are asserted here. Mandatory-validation,
-  # error-clearing and default-selection cases require a required=true / default
-  # schema and are covered separately when such a schema is available.
-
+  # These fields are optional in the esqa2 spec, so only rendering and input behaviour are asserted
   Background:
     Given user directly navigates to sign-up portal URL
     And user clicks on Register button

--- a/ui-test/src/main/resources/featurefiles/SignupDynamicFormFields.feature
+++ b/ui-test/src/main/resources/featurefiles/SignupDynamicFormFields.feature
@@ -27,6 +27,7 @@ Feature: Esignet Signup - Dynamic Setup Account form fields
     When user selects an option in the "gender" radio field
     Then verify one option is selected in the "gender" radio field
     When user selects two different options in the "gender" radio field
+    Then verify one option is selected in the "gender" radio field
 
   @regression @textareaField
   Scenario: Textarea renders with default rows and placeholder and accepts input

--- a/ui-test/src/main/resources/featurefiles/SignupDynamicFormFields.feature
+++ b/ui-test/src/main/resources/featurefiles/SignupDynamicFormFields.feature
@@ -1,0 +1,51 @@
+Feature: Esignet Signup - Dynamic Setup Account form fields
+  Verifying the radio, textarea and file-upload fields the JsonFormBuilder renders
+  on the Setup Account form from the deployed UI-spec (esqa2: gender, details,
+  passport, photo).
+
+  # These fields are optional (required=false) in the esqa2 spec, so only
+  # rendering and input behaviour are asserted here. Mandatory-validation,
+  # error-clearing and default-selection cases require a required=true / default
+  # schema and are covered separately when such a schema is available.
+
+  Background:
+    Given user directly navigates to sign-up portal URL
+    And user clicks on Register button
+    And user enters valid_mobile_number in the mobile number text box
+    Then mark otp request timestamp
+    And user clicks on the Continue button
+    When user enters the complete 6-digit OTP
+    And user clicks on the Verify OTP button
+    Then remove otp request timestamp
+    And verify user is redirected to the success screen
+    When user click on Continue button in Success Screen
+    Then verify setup account screen is displayed with header Setup Account
+
+  @regression @radioField
+  Scenario: Radio field renders with options and enforces single selection
+    Then verify the "gender" radio field is rendered with its label and options
+    When user selects an option in the "gender" radio field
+    Then verify one option is selected in the "gender" radio field
+    When user selects two different options in the "gender" radio field
+
+  @regression @textareaField
+  Scenario: Textarea renders with default rows and placeholder and accepts input
+    Then verify the "details" textarea field is rendered
+    And verify the "details" textarea has 2 default rows
+    And verify the "details" textarea placeholder is rendered
+    When user enters text into the "details" textarea
+    Then verify the "details" textarea retains the entered text
+
+  @regression @fileUploadField
+  Scenario: Passport upload enforces supported file types
+    Then verify the "passport" file upload field is rendered with its label
+    When user uploads an unsupported file for the "passport" field
+    Then verify an unsupported file error is shown for the "passport" field
+    When user uploads a supported document for the "passport" field
+    Then verify the supported file is accepted for the "passport" field
+
+  @regression @fileUploadField
+  Scenario: Photo upload accepts a supported image
+    Then verify the "photo" file upload field is rendered with its label
+    When user uploads a supported document for the "photo" field
+    Then verify the supported file is accepted for the "photo" field

--- a/ui-test/src/main/resources/featurefiles/SignupUnifiedLogin.feature
+++ b/ui-test/src/main/resources/featurefiles/SignupUnifiedLogin.feature
@@ -1,0 +1,33 @@
+Feature: Esignet Signup via Unified Login
+  UI happy-path for the "audit the signup events" test case: from the relying
+  party, register a mobile number through "Sign-Up with Unified Login", verify
+  the OTP, and proceed from the mobile-verified success screen to Account Setup.
+
+  # Audit-log verification (GENERATE_CHALLENGE / VERIFY_CHALLENGE / REGISTER /
+  # REGISTER_STATUS_CHECK and their success/failure event types) is intentionally
+  # OUT OF SCOPE here: the signup service emits those audits server-to-server to
+  # the audit-manager (stored in the mosip_audit DB), so they are not observable
+  # from the browser. They are verifiable only at the API/DB layer (api-test's
+  # mosip_audit access) and are tracked separately.
+  #
+  # Every step below is reused from the existing login/registration glue; this
+  # scenario overlaps the happy-path portion of @loginFeature and adds no new
+  # step code - it exists as a dedicated, traceable case for this test.
+  @signupUnifiedLogin @smoke
+  Scenario: Verify mobile number and proceed to account setup via Unified Login
+    Given click on Sign In with eSignet
+    When user clicks on the Sign-Up with Unified Login hyperlink
+    Then verify user is navigated to the Mobile Number Registration screen
+
+    When user enter valid mobile number in the mobile number field
+    Then mark otp request timestamp
+    And user clicks on the Continue button
+    Then verify user is navigated to the OTP screen
+
+    When user enters the correct OTP as input
+    And user clicks on the Verify OTP button
+    Then remove otp request timestamp
+    And verify user is redirected to the success screen
+
+    Then user clicks on continue button on success page
+    And user redirected to registration page

--- a/ui-test/src/main/resources/featurefiles/SignupUnifiedLogin.feature
+++ b/ui-test/src/main/resources/featurefiles/SignupUnifiedLogin.feature
@@ -3,16 +3,7 @@ Feature: Esignet Signup via Unified Login
   party, register a mobile number through "Sign-Up with Unified Login", verify
   the OTP, and proceed from the mobile-verified success screen to Account Setup.
 
-  # Audit-log verification (GENERATE_CHALLENGE / VERIFY_CHALLENGE / REGISTER /
-  # REGISTER_STATUS_CHECK and their success/failure event types) is intentionally
-  # OUT OF SCOPE here: the signup service emits those audits server-to-server to
-  # the audit-manager (stored in the mosip_audit DB), so they are not observable
-  # from the browser. They are verifiable only at the API/DB layer (api-test's
-  # mosip_audit access) and are tracked separately.
-  #
-  # Every step below is reused from the existing login/registration glue; this
-  # scenario overlaps the happy-path portion of @loginFeature and adds no new
-  # step code - it exists as a dedicated, traceable case for this test.
+  # Audit logs are emitted server-to-server, so they are out of scope here and covered at the API layer
   @signupUnifiedLogin @smoke
   Scenario: Verify mobile number and proceed to account setup via Unified Login
     Given click on Sign In with eSignet

--- a/ui-test/src/main/resources/featurefiles/TransactionTimeout.feature
+++ b/ui-test/src/main/resources/featurefiles/TransactionTimeout.feature
@@ -1,0 +1,31 @@
+Feature: Esignet Signup Transaction Timeout
+  Verifying that, when the signup transaction has expired, proceeding with the
+  registration shows the transaction-timeout error popup
+  (Header: "Error!", the localized timeout message, Button: "Okay").
+
+  # Entry is the relying party ("Sign In with eSignet" -> "Sign-Up with Unified
+  # Login"), reusing the existing login/registration steps. A real expiry takes
+  # ~5 minutes (mosip.signup.*.txn.timeout = 300s), so via CDP we stub
+  # generate-challenge to succeed (reaching the OTP screen deterministically,
+  # without depending on real SMS/send-OTP throttling) and verify-challenge to
+  # return the backend's invalid_transaction error - the same critical error a
+  # genuine expiry raises when the user clicks Verify OTP. CDP interception is
+  # local-Chrome only, hence @localOnly (skipped on BrowserStack).
+  @transactionTimeout @localOnly
+  Scenario: Setup account after the signup transaction has expired
+    Given click on Sign In with eSignet
+    When user clicks on the Sign-Up with Unified Login hyperlink
+    Then verify user is navigated to the Mobile Number Registration screen
+    When user enter valid mobile number in the mobile number field
+    Given the signup transaction is forced to expire on OTP verification
+    And user clicks on the Continue button
+    Then verify user is navigated to the OTP screen
+
+    When user enters "111111" as a Otp
+    And user clicks on the Verify OTP button
+
+    Then verify the transaction timeout error popup is displayed
+    And verify the error popup header shows the error title
+    And verify the error popup message shows the transaction timeout message
+    And verify the error popup has an Okay button
+    When user clicks on the Okay button in the error popup

--- a/ui-test/src/main/resources/featurefiles/TransactionTimeout.feature
+++ b/ui-test/src/main/resources/featurefiles/TransactionTimeout.feature
@@ -3,14 +3,7 @@ Feature: Esignet Signup Transaction Timeout
   registration shows the transaction-timeout error popup
   (Header: "Error!", the localized timeout message, Button: "Okay").
 
-  # Entry is the relying party ("Sign In with eSignet" -> "Sign-Up with Unified
-  # Login"), reusing the existing login/registration steps. A real expiry takes
-  # ~5 minutes (mosip.signup.*.txn.timeout = 300s), so via CDP we stub
-  # generate-challenge to succeed (reaching the OTP screen deterministically,
-  # without depending on real SMS/send-OTP throttling) and verify-challenge to
-  # return the backend's invalid_transaction error - the same critical error a
-  # genuine expiry raises when the user clicks Verify OTP. CDP interception is
-  # local-Chrome only, hence @localOnly (skipped on BrowserStack).
+  # A real expiry takes ~5 minutes, so verify-challenge is stubbed to return invalid_transaction
   @transactionTimeout @localOnly
   Scenario: Setup account after the signup transaction has expired
     Given click on Sign In with eSignet


### PR DESCRIPTION
### What
Adds Selenium/Cucumber UI test coverage for three signup flows:
- Error-handler page (HTTP 4XX/5XX) with language switch
- Transaction-timeout popup
- Unified-login signup

### Notable changes
- New feature files, page objects and step definitions for the above
- Helpers: `LocaleTextUtil` (locale assertions) and CDP interceptors for faking API responses
- OTP / verify-button reliability fixes
- Bumped Selenium 4.14.1 → 4.45.0 (DevTools v149)

### Notes
CDP-based scenarios are tagged `@localOnly` (skipped on BrowserStack).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new UI test flows: “Something went wrong” error handler (language switching + HTTP-error assertions), transaction-timeout popup coverage, and unified-login smoke path.
  * Introduced dynamic “Setup Account” form testing for radio, textarea, and file upload fields.
  * Added multilingual eSignet password and verified OTP support.
* **Bug Fixes**
  * Improved test reliability with clickability-based waits, transient-failure retry logic, and visibility-synchronized element lookups.
* **Chores**
  * Refreshed test build configuration (repository metadata, Selenium version) and cleaned up config whitespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->